### PR TITLE
Sign in fix for Firefox

### DIFF
--- a/src/components/index.css
+++ b/src/components/index.css
@@ -26,7 +26,7 @@
 .sidebar-dimmer {
   position: absolute;
   background: #4444445b;
-  z-index: 2;
+  z-index: 100;
   width: 100vw;
   height: 100vh;
   top: 0;


### PR DESCRIPTION
Fixed the sign in issue on Firefox by adding a unique `state` param to Auth0's authorization request