### PR TITLE
added scripts to download config.js and specify backend

### DIFF
--- a/changeBackend.js
+++ b/changeBackend.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const chalk = require('chalk');
+const axios = require('axios')
+const { program } = require('commander');
+
+
+backendList = {
+  production : "https://classtranscribe.illinois.edu",
+  dev  : "https://classtranscribe-dev.ncsa.illinois.edu"
+}
+
+
+/**
+ * adds REACT_APP_TESTING_BASE_URL env var to the config file
+ *
+ * @param {string} data    config.js file data
+ * @param {string} url     url of chosen backend
+ */
+function change(data, url) {
+    let serverEnv = "window.env.REACT_APP_TESTING_BASE_URL"
+    let env = `${serverEnv}="${url}"\n`
+    return(data + env )
+}
+
+/**
+ * gets config data from url and adds new env var
+ * before saving config file in /public dir
+ *
+ * @param {string} url    url of chosen backend
+ */
+async function setBackend(url) {
+  let data = await axios.get(`${backendList["dev"]}/config.js`)
+                  .then(({data}) => data)
+                  .catch(err => {})
+  if (!data) {
+    console.log(chalk.red.bold(`Could not connect to server ${url}`))
+    return
+  }
+  data = change(data, url);
+    
+  try {
+    fs.writeFileSync("./public/config.js", data)
+    console.log(chalk.green(`Backend : ${chalk.bold(url)}`))
+  }
+  catch(err) {
+    console.log(chalk.red.bold(err))
+  }
+}
+
+/**
+ * processs command line arguments to select 
+ * dev or production server
+ */
+function processArgs() {
+  program
+    .option('-p --production', backendList.production )
+    .option('-d --dev', backendList.dev)
+
+  program.parse(process.argv);
+  let backend =  Object.keys(program.opts())
+
+  if (backend.length !== 1) {
+    console.log(chalk.red(`Invalid args \nType : ${chalk.bold("yarn backend -h")}`))
+    return
+  }
+  setBackend(backendList[backend[0]]);
+}
+
+/**
+ * runs processArgs only if the file is called as an export
+ */
+if (require.main === module) {
+    processArgs();
+}
+
+
+module.exports.setBackend = setBackend;
+

--- a/changeBackend.js
+++ b/changeBackend.js
@@ -23,21 +23,21 @@ function change(data, url) {
 }
 
 /**
- * gets config data from url and adds new env var
- * before saving config file in /public dir
- *
- * @param {string} url    url of chosen backend
+ * fetches config file
+ * @param {string} url     url of chosen backend
  */
-async function setBackend(url) {
-  let data = await axios.get(`${backendList["dev"]}/config.js`)
+async function fetchConfig(url) {
+  let data = await axios.get(`${url}/config.js`)
                   .then(({data}) => data)
                   .catch(err => {})
-  if (!data) {
-    console.log(chalk.red.bold(`Could not connect to server ${url}`))
-    return
-  }
-  data = change(data, url);
-    
+  return data;
+}
+
+/**
+ * saves data to "./public/config"
+ * @param {string} data     url of chosen backend
+ */
+function saveToPublicDir(data, url) {
   try {
     fs.writeFileSync("./public/config.js", data)
     console.log(chalk.green(`Backend : ${chalk.bold(url)}`))
@@ -47,23 +47,67 @@ async function setBackend(url) {
   }
 }
 
+
+/**
+ * gets config data from url and adds new env var
+ * before saving config file in /public dir
+ * @param {string} url    url of chosen backend
+ */
+async function setBackend(url) {
+  let data =  await fetchConfig(url)
+  
+  if (!data) {
+    console.log(chalk.red.bold(`Could not connect to server ${url} `))
+    return
+  }
+  data = change(data, url);
+  saveToPublicDir(data, url);
+}
+
+
+/**
+ * gets config data from dev and sets backend to custom address
+ * before saving config file in /public dir
+ * @param {string} url    url of chosen backend
+ */
+async function setCustomBackend({localhost : url}) {
+  
+  if (!url.startsWith("http://localhost")) {
+    console.log(chalk.red(`The server address must be complete \ni.e. ${chalk.bold("https://localhost[...]")}`))
+    return;
+  }
+  
+  let data = await fetchConfig(backendList['dev'])
+  
+  if (!data) {
+    console.log(chalk.red.bold(`Could not connect to server ${backendList['dev']} `))
+    return
+  }
+  data = change(data, url);
+  saveToPublicDir(data, url);
+}
+
 /**
  * processs command line arguments to select 
  * dev or production server
  */
 function processArgs() {
   program
-    .option('-p --production', backendList.production )
+    .option('-p --production', `${backendList.production} (Currently not working)` )
     .option('-d --dev', backendList.dev)
+    .option('-l --localhost <string>', "complete Localhost address")
 
   program.parse(process.argv);
   let backend =  Object.keys(program.opts())
-
+  
   if (backend.length !== 1) {
     console.log(chalk.red(`Invalid args \nType : ${chalk.bold("yarn backend -h")}`))
     return
   }
-  setBackend(backendList[backend[0]]);
+  if (backend[0] === "localhost")
+    setCustomBackend(program.opts())
+  else 
+    setBackend(backendList[backend[0]]);
 }
 
 /**

--- a/getDefaultConfig.js
+++ b/getDefaultConfig.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const chalk = require('chalk');
+const {setBackend} = require("./changeBackend");
+
+
+
+
+let url = "https://classtranscribe-dev.ncsa.illinois.edu"
+
+try {
+  if (!fs.existsSync("./public/config.js")) {
+    setBackend(url)
+    return;
+  }
+} 
+catch(err) {
+  console.log(chalk.red(err))
+}
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -562,7 +562,6 @@
       "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
-        "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
@@ -1378,7 +1377,6 @@
       "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
       "requires": {
         "@jest/source-map": "^24.9.0",
-        "chalk": "^2.0.1",
         "slash": "^2.0.0"
       }
     },
@@ -1393,7 +1391,6 @@
         "@jest/transform": "^24.9.0",
         "@jest/types": "^24.9.0",
         "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.15",
         "jest-changed-files": "^24.9.0",
@@ -1424,7 +1421,6 @@
           "requires": {
             "@jest/types": "^24.9.0",
             "browser-resolve": "^1.11.3",
-            "chalk": "^2.0.1",
             "jest-pnp-resolver": "^1.2.1",
             "realpath-native": "^1.1.0"
           }
@@ -1461,7 +1457,6 @@
         "@jest/test-result": "^24.9.0",
         "@jest/transform": "^24.9.0",
         "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "glob": "^7.1.2",
         "istanbul-lib-coverage": "^2.0.2",
@@ -1487,7 +1482,6 @@
           "requires": {
             "@jest/types": "^24.9.0",
             "browser-resolve": "^1.11.3",
-            "chalk": "^2.0.1",
             "jest-pnp-resolver": "^1.2.1",
             "realpath-native": "^1.1.0"
           }
@@ -1533,7 +1527,6 @@
         "@babel/core": "^7.1.0",
         "@jest/types": "^24.9.0",
         "babel-plugin-istanbul": "^5.1.0",
-        "chalk": "^2.0.1",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.1.15",
@@ -2963,11 +2956,18 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+          "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+        }
       }
     },
     "axobject-query": {
@@ -3069,7 +3069,6 @@
         "@types/babel__core": "^7.1.0",
         "babel-plugin-istanbul": "^5.1.0",
         "babel-preset-jest": "^24.9.0",
-        "chalk": "^2.4.2",
         "slash": "^2.0.0"
       }
     },
@@ -3875,21 +3874,41 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -4194,7 +4213,6 @@
       "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
       "requires": {
         "@types/q": "^1.5.1",
-        "chalk": "^2.4.1",
         "q": "^1.1.2"
       }
     },
@@ -4267,11 +4285,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "common-tags": {
       "version": "1.8.0",
@@ -5796,7 +5809,6 @@
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.9.1",
-        "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
@@ -6774,7 +6786,6 @@
       "integrity": "sha512-zEhg7Hz+KhZlBhILYpXy+Beu96gwvkROWJiTXOCyOOMMrdBIRPvsBpBqgTI4jfJGrJXcqGwJR8zsBGDmzY0jsA==",
       "requires": {
         "babel-code-frame": "^6.22.0",
-        "chalk": "^2.4.1",
         "chokidar": "^2.0.4",
         "micromatch": "^3.1.10",
         "minimatch": "^3.0.4",
@@ -7874,7 +7885,6 @@
       "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "requires": {
         "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
@@ -8401,7 +8411,6 @@
             "@jest/core": "^24.9.0",
             "@jest/test-result": "^24.9.0",
             "@jest/types": "^24.9.0",
-            "chalk": "^2.0.1",
             "exit": "^0.1.2",
             "import-local": "^2.0.0",
             "is-ci": "^2.0.0",
@@ -8434,7 +8443,6 @@
         "@jest/test-sequencer": "^24.9.0",
         "@jest/types": "^24.9.0",
         "babel-jest": "^24.9.0",
-        "chalk": "^2.0.1",
         "glob": "^7.1.1",
         "jest-environment-jsdom": "^24.9.0",
         "jest-environment-node": "^24.9.0",
@@ -8456,7 +8464,6 @@
           "requires": {
             "@jest/types": "^24.9.0",
             "browser-resolve": "^1.11.3",
-            "chalk": "^2.0.1",
             "jest-pnp-resolver": "^1.2.1",
             "realpath-native": "^1.1.0"
           }
@@ -8468,7 +8475,6 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
       "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
       "requires": {
-        "chalk": "^2.0.1",
         "diff-sequences": "^24.9.0",
         "jest-get-type": "^24.9.0",
         "pretty-format": "^24.9.0"
@@ -8488,7 +8494,6 @@
       "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
       "requires": {
         "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
         "jest-get-type": "^24.9.0",
         "jest-util": "^24.9.0",
         "pretty-format": "^24.9.0"
@@ -8696,7 +8701,6 @@
         "@jest/environment": "^24.9.0",
         "@jest/test-result": "^24.9.0",
         "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
         "co": "^4.6.0",
         "expect": "^24.9.0",
         "is-generator-fn": "^2.0.0",
@@ -8724,7 +8728,6 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
       "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
       "requires": {
-        "chalk": "^2.0.1",
         "jest-diff": "^24.9.0",
         "jest-get-type": "^24.9.0",
         "pretty-format": "^24.9.0"
@@ -8739,7 +8742,6 @@
         "@jest/test-result": "^24.9.0",
         "@jest/types": "^24.9.0",
         "@types/stack-utils": "^1.0.1",
-        "chalk": "^2.0.1",
         "micromatch": "^3.1.10",
         "slash": "^2.0.0",
         "stack-utils": "^1.0.1"
@@ -8770,7 +8772,6 @@
       "requires": {
         "@jest/types": "^24.7.0",
         "browser-resolve": "^1.11.3",
-        "chalk": "^2.0.1",
         "jest-pnp-resolver": "^1.2.1",
         "realpath-native": "^1.1.0"
       }
@@ -8794,7 +8795,6 @@
         "@jest/environment": "^24.9.0",
         "@jest/test-result": "^24.9.0",
         "@jest/types": "^24.9.0",
-        "chalk": "^2.4.2",
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.15",
         "jest-config": "^24.9.0",
@@ -8818,7 +8818,6 @@
           "requires": {
             "@jest/types": "^24.9.0",
             "browser-resolve": "^1.11.3",
-            "chalk": "^2.0.1",
             "jest-pnp-resolver": "^1.2.1",
             "realpath-native": "^1.1.0"
           }
@@ -8836,7 +8835,6 @@
         "@jest/transform": "^24.9.0",
         "@jest/types": "^24.9.0",
         "@types/yargs": "^13.0.0",
-        "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.1.15",
@@ -8862,7 +8860,6 @@
           "requires": {
             "@jest/types": "^24.9.0",
             "browser-resolve": "^1.11.3",
-            "chalk": "^2.0.1",
             "jest-pnp-resolver": "^1.2.1",
             "realpath-native": "^1.1.0"
           }
@@ -8881,7 +8878,6 @@
       "requires": {
         "@babel/types": "^7.0.0",
         "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
         "expect": "^24.9.0",
         "jest-diff": "^24.9.0",
         "jest-get-type": "^24.9.0",
@@ -8901,7 +8897,6 @@
           "requires": {
             "@jest/types": "^24.9.0",
             "browser-resolve": "^1.11.3",
-            "chalk": "^2.0.1",
             "jest-pnp-resolver": "^1.2.1",
             "realpath-native": "^1.1.0"
           }
@@ -8924,7 +8919,6 @@
         "@jest/test-result": "^24.9.0",
         "@jest/types": "^24.9.0",
         "callsites": "^3.0.0",
-        "chalk": "^2.0.1",
         "graceful-fs": "^4.1.15",
         "is-ci": "^2.0.0",
         "mkdirp": "^0.5.1",
@@ -8939,7 +8933,6 @@
       "requires": {
         "@jest/types": "^24.9.0",
         "camelcase": "^5.3.1",
-        "chalk": "^2.0.1",
         "jest-get-type": "^24.9.0",
         "leven": "^3.1.0",
         "pretty-format": "^24.9.0"
@@ -8951,7 +8944,6 @@
       "integrity": "sha512-+uOtlppt9ysST6k6ZTqsPI0WNz2HLa8bowiZylZoQCQaAVn7XsVmHhZREkz73FhKelrFrpne4hQQjdq42nFEmA==",
       "requires": {
         "ansi-escapes": "^3.0.0",
-        "chalk": "^2.4.1",
         "jest-watcher": "^24.3.0",
         "slash": "^2.0.0",
         "string-length": "^2.0.0",
@@ -8967,7 +8959,6 @@
         "@jest/types": "^24.9.0",
         "@types/yargs": "^13.0.0",
         "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
         "jest-util": "^24.9.0",
         "string-length": "^2.0.0"
       }
@@ -9336,10 +9327,7 @@
     "katex": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
-      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
-      "requires": {
-        "commander": "^2.19.0"
-      }
+      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww=="
     },
     "keyboard-key": {
       "version": "1.1.0",
@@ -15905,7 +15893,6 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
       "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
       "requires": {
-        "chalk": "^2.4.2",
         "source-map": "^0.6.1",
         "supports-color": "^6.1.0"
       }
@@ -16761,7 +16748,6 @@
       "integrity": "sha512-aLb6vtOTEfJDwi1w+MBTeE20GwPVUYyn6IqNg6TtGpiOB1W3y6vKcsGFjqGeaaEtQgMLSPXTWONqh33UBuwG8A==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
         "execa": "^2.1.0",
         "find-up": "^4.1.0",
         "ignore": "^5.1.4",
@@ -17355,7 +17341,6 @@
         "@babel/code-frame": "7.5.5",
         "address": "1.1.2",
         "browserslist": "4.7.0",
-        "chalk": "2.4.2",
         "cross-spawn": "6.0.5",
         "detect-port-alt": "1.1.6",
         "escape-string-regexp": "1.0.5",
@@ -17408,7 +17393,6 @@
           "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
           "requires": {
             "ansi-escapes": "^3.2.0",
-            "chalk": "^2.4.2",
             "cli-cursor": "^2.1.0",
             "cli-width": "^2.0.0",
             "external-editor": "^3.0.3",
@@ -17910,8 +17894,7 @@
           "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
           "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
           "requires": {
-            "ast-types-flow": "0.0.7",
-            "commander": "^2.11.0"
+            "ast-types-flow": "0.0.7"
           }
         },
         "eslint-plugin-import": {
@@ -19936,7 +19919,6 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
       "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
       "requires": {
-        "chalk": "^2.4.1",
         "coa": "^2.0.2",
         "css-select": "^2.0.0",
         "css-select-base-adapter": "^0.1.1",
@@ -20008,7 +19990,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
       "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "requires": {
-        "commander": "^2.20.0",
         "source-map": "~0.6.1",
         "source-map-support": "~0.5.12"
       }
@@ -20059,7 +20040,6 @@
           "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
           "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
           "requires": {
-            "commander": "^2.19.0",
             "source-map": "~0.6.1",
             "source-map-support": "~0.5.10"
           }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "lint:fix": "yarn lint --fix",
     "lint:fix:quiet": "yarn lint:fix --quiet",
     "prettier": "prettier --list-different \"**/*.{js,jsx,ts,tsx}\"",
-    "prettier:fix": "prettier --write \"**/*.{js,jsx,ts,tsx}\""
+    "prettier:fix": "prettier --write \"**/*.{js,jsx,ts,tsx}\"",
+    "backend": "node changeBackend",
+    "postinstall": "node getdefaultConfig"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -48,7 +50,9 @@
     "babel": "^6.23.0",
     "bootstrap": "^4.4.1",
     "braft-editor": "^2.3.9",
+    "chalk": "^4.1.0",
     "classnames": "^2.2.6",
+    "commander": "^7.1.0",
     "dentist": "^1.0.3",
     "dva": "^2.4.1",
     "harmony-reflect": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3935,6 +3935,11 @@ commander@^6.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
   integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
 
+commander@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
+  integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
+
 commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"


### PR DESCRIPTION
1. `yarn install` automatically downloads config from -dev envr
2. `yarn backend -args` is used to specify backend of choice.
3. A local host address can be set. eg `yarn backend -l http://localhost...`
4.  Thoroughly tested and with helpful logging of messages and errors