### PR TITLE
Fix exiting fullscreen via button press

### DIFF
--- a/src/screens/Watch/Components/ControlBar/CtrlButtons/FullscreenButton.jsx
+++ b/src/screens/Watch/Components/ControlBar/CtrlButtons/FullscreenButton.jsx
@@ -12,7 +12,7 @@ export function FullscreenButtonWithRedux({ isFullscreen = false, dispatch }) {
       onClick={handleFullscreen}
       label={isFullscreen ? 'Exit Fullscreen (f)' : 'Enter Fullscreen (f)'}
       ariaTags={{
-        'aria-label': isFullscreen ? 'Enter Fullscreen' : 'Enter Fullscreen',
+        'aria-label': isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen',
         // 'aria-keyshortcuts': 'f'
       }}
       id="fullscreen-btn"

--- a/src/screens/Watch/model/player_effects.js
+++ b/src/screens/Watch/model/player_effects.js
@@ -166,10 +166,10 @@ export default {
         if (newState) {
             if (!PlayerData.video1) return;
             if (newState) {
-                enterFullScreen()
+                enterFullScreen(watch)
                 yield put({ type: 'playerpref/setTransView', payload: { view: null, config: { updatePrefer: false } } });
             } else {
-                exitFullScreen()
+                exitFullScreen(watch)
                 yield put({ type: 'playerpref/setTransView', payload: { view: HIDE_TRANS, config: { updatePrefer: false } } });
             }
         }

--- a/src/screens/Watch/model/player_effects.js
+++ b/src/screens/Watch/model/player_effects.js
@@ -163,7 +163,7 @@ export default {
     *toggleFullScreen({ payload: bool }, { call, put, select, take }) {
         const { watch, playerpref } = yield select();
         const newState = bool === undefined ? !watch.isFullscreen : bool;
-        if (newState) {
+        if (newState !== undefined) {
             if (!PlayerData.video1) return;
             if (newState) {
                 enterFullScreen(watch)


### PR DESCRIPTION
There is currently a bug where pressing the fullscreen button does not allow the user to exit the fullscreen view. This issue was exhibited on Chrome and Firefox browsers.

In the handler, there is a check to see if the ``newState`` is undefined or not. However, it was evaluating the truth value of the variable, instead of whether it was undefined. So, the fullscreen button only worked when the variable was ``true``, which was when entering fullscreen, and did not work when exiting. 

Also, I fixed the ``aria-label`` for the fullscreen button, it was not being updated properly when the view was in fullscreen mode.

Lastly, the handler was not passing the ``watch`` object to ``enterFullScreen`` and ``exitFullScreen``, causing an error to be logged to the console when pressing the button.

Closes #325 