### PR TITLE
allow for cilogon IDP selection/dfault

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -43,6 +43,14 @@ class ReactEnv {
     return reactEnv.CILOGON_CLIENT_ID;
   }
 
+  get ciLogonSelectedIDP() {
+    return reactEnv.CILOGON_SELECTED_IDP || '';
+  }
+
+  get ciLogonDefaultIDP() {
+    return reactEnv.CILOGON_DEFAULT_IDP || 'urn:mace:incommon:uiuc.edu';
+  }
+
   get frontendCommitEndpoint() {
     return reactEnv.REACT_APP_FRONTEND_COMMIT_ENDPOINT;
   }

--- a/src/utils/user/CILogon.js
+++ b/src/utils/user/CILogon.js
@@ -14,6 +14,8 @@ export class CILogon {
     const query = uurl.createSearch({
       response_type: 'code',
       client_id: env.ciLogonClientID,
+      selected_idp: env.ciLogonSelectedIDP,
+      initialidp: env.ciLogonDefaultIDP,
       redirect_uri: this.callback,
       scope: 'openid profile email org.cilogon.userinfo edu.uiuc.ncsa.myproxy.getcert',
     });


### PR DESCRIPTION
Can now set the following environment variables:

CILOGON_SELECTED_IDP (default '') this will allow to select the IDPs that are shown. List can be found at https://cilogon.org/include/idplist.xml

CILOGON_DEFAULT_IDP (default 'urn:mace:incommon:uiuc.edu', UIUC) select one of the ones above to be shown as the default IDP.
