### PR TITLE
fix: overlapping subchapter title and text in PDF output

### DIFF
--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -119,6 +119,7 @@ class HTMLFileBuilder {
           // Print subchapter title
           y += 10;
           pdf.text(`${i+1}-${j+1} ${subchapter.title}`, margin, y, 'left');
+          y += 10;
 
           // Add subchapter to outline
           pdf.outline.add(null, subchapter.title, {pageNumber:pageCurrent});


### PR DESCRIPTION
## Problem
Subchapter title and contents would occasionally overlap: 
<img width="603" alt="Screen Shot 2022-02-10 at 12 27 22 PM" src="https://user-images.githubusercontent.com/1413653/153472727-e48bba27-bd89-4e33-a0f4-e307903e91d9.png">

## Approach
Add an additional `y += 10` after printing the subchapter title. This should prevent the overlap, but there may be additional edge cases that need to be covered for when this value for y lies off the screen

## How to Test
1. Navigate to ct-dev and login as Test User
2. Navigate to https://ct-dev.ncsa.illinois.edu/epub/f4e07edf-fd15-4e46-ba1a-52e51a2f4dd5#view=v-structure&from=new
3. At the top-right choose "View ePub (Read Only)"
4. On the right side choose "Print/save as PDF file"
5. Examine the PDF for correctness, notably the section containing the subchapters
    * You should see the subchapter title and "text 2" no longer collide