### PR TITLE
Fix "New Subchapter" format

### DIFF
--- a/src/screens/EPub/models/data_reducer.js
+++ b/src/screens/EPub/models/data_reducer.js
@@ -3,10 +3,9 @@ import { EPubData, EPubChapterData, EPubSubChapterData, EPubImageData } from 'en
 import { getAllItemsInChapters } from 'entities/EPubs/utils'
 
 function insertSubChapter(chapter, subChapterIndex, subChapterLike) {
-    let newSubChapter = new EPubSubChapterData(subChapterLike).toObject();
-    if (newSubChapter.__data__) {
-        newSubChapter = newSubChapter.__data__;
-    }
+    let newSubChapter = new EPubSubChapterData(subChapterLike);
+    newSubChapter = newSubChapter.__data__ ? newSubChapter.__data__ : newSubChapter.toObject();
+
     chapter.subChapters = [
         ...chapter.subChapters.slice(0, subChapterIndex),
         newSubChapter,
@@ -25,12 +24,11 @@ function removeSubChapter(chapter, subChapterIndex) {
 }
 function insertChapter(chapters, index, chapterLike) {
     let newChapter = new EPubChapterData(chapterLike);
-    if (newChapter.__data__) {
-        newChapter = newChapter.__data__;
-    }
+    newChapter = newChapter.__data__ ? newChapter.__data__ : newChapter.toObject();
+
     return [
         ...chapters.slice(0, index),
-        newChapter.toObject(),
+        newChapter,
         ...chapters.slice(index)
     ];
 }

--- a/src/screens/EPub/models/data_reducer.js
+++ b/src/screens/EPub/models/data_reducer.js
@@ -4,6 +4,9 @@ import { getAllItemsInChapters } from 'entities/EPubs/utils'
 
 function insertSubChapter(chapter, subChapterIndex, subChapterLike) {
     let newSubChapter = new EPubSubChapterData(subChapterLike).toObject();
+    if (newSubChapter.__data__) {
+        newSubChapter = newSubChapter.__data__;
+    }
     chapter.subChapters = [
         ...chapter.subChapters.slice(0, subChapterIndex),
         newSubChapter,
@@ -27,7 +30,7 @@ function insertChapter(chapters, index, chapterLike) {
     }
     return [
         ...chapters.slice(0, index),
-        newChapter,
+        newChapter.toObject(),
         ...chapters.slice(index)
     ];
 }
@@ -107,7 +110,7 @@ function rebuildSubChapter(chapters, chapterIndex, subChapterIndex, subChapterLi
       // update the subchapter item
       if (subChapters[subChapterIndex]) {
         let toBuild = subChapterLike || subChapters[subChapterIndex];
-        subChapters[subChapterIndex] = new EPubSubChapterData(toBuild, resetText);
+        subChapters[subChapterIndex] = new EPubSubChapterData(toBuild, resetText).toObject();
       }
     }
   }

--- a/src/screens/EPub/views/EditEPubStructure/ChapterList/EPubSubChapterItem.js
+++ b/src/screens/EPub/views/EditEPubStructure/ChapterList/EPubSubChapterItem.js
@@ -110,7 +110,7 @@ function EPubSubChapterItem({
             </CTText>
             :
             <div className="ch-item-ol ct-d-c">
-              {subChapter.items.map((item, itemIndex) => (
+              {subChapter?.items?.map((item, itemIndex) => (
                 <EPubListItem
                   isSubChapter
                   key={item.id}


### PR DESCRIPTION
## Problem
Previously (in #454), we fixed the format being used/set by `rebuildChapter` when splitting a chapter into two.

Unfortunately, the same problematic behavior exists in `rebuildSubChapter` when splitting a subchapter into two, where the split subchapter only contains a `__data__` field (which in turn has all of the correct properties)

When this scenario is encountered, the UI becomes unresponsive and typically only a blank page is seen

## Approach
Use the same pattern as #454 to prevent the subchapter data from being mangled by this method.

This may not be the correct approach to fixing this bug, but it does appear to prevent the data format problem from occurring and restores functionality of the UI

## How to Test
NOTE: After each step, wait a few seconds before refreshing the page - it seems that if you refresh too quickly, this appears to cancel the request to the server. I need to look into why this happens and how to prevent it

1. Checkout and run this branch locally, rebuild the FrontEnd
2. Create a New ePub
3. Split some chapters, count to 3, and refresh the page
    * Notice that things are still working as expected
    * You should *NOT* see only a blank page after refreshing
4. Create a new subchapter, count to 3, and refresh the page
    * Notice that things are still working as expected
    * You should *NOT* see only a blank page after refreshing
5. From somewhere within the existing subchapter, choose "New Subchapter", count to 3, and refresh the page
    * Notice that things are still working as expected
    * You should *NOT* see only a blank page after refreshing
6. Compare step 5 with existing ct-dev behavior
