### PR TITLE
enable title detection

### DIFF
--- a/src/screens/EPub/models/data_reducer.js
+++ b/src/screens/EPub/models/data_reducer.js
@@ -310,7 +310,7 @@ export default {
             (data, idx) =>
                 new EPubChapterData({
                     items: [data],
-                    title: `Untitled Chapter ${idx + 1}`,
+                    title: data.title,
                 }).toObject(),
         );
         return { ...state, epub: { ...state.epub, ...nextStateOfChapters(splitChapters) } };


### PR DESCRIPTION
Deployed the title detection feature to the frontend.
When creating a new ePub file, the default title for each subchapter is generated from the title detection algorithm applied to the detected video segment.