### PR TITLE
timeout bug for fetching playlist data

### DIFF
--- a/src/utils/cthttp/entities/Logs.js
+++ b/src/utils/cthttp/entities/Logs.js
@@ -46,7 +46,7 @@ export function getUserSearchHistoryInOffering(offeringId) {
 }
 
 export function getPlayListsByCourseId(offeringId) {
-  return cthttp.get(`Playlists/ByOffering2/${ offeringId}`, { params: { offeringId } });
+  return cthttp.get(`Playlists/ByOffering2/${ offeringId}`, { params: { offeringId }, timeout : GET_LOG_TIMEOUT });
 }
 export function getAllCourseLogs(eventType, offeringId, start, end) {
   return cthttp.get('Logs/AllCourseLogs', {


### PR DESCRIPTION
There was a timeout bug for the analytics page where the playlist data would not fetch within the default timeout