### PR TITLE
Possible LaTeX conversion patterns

### DIFF
--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -263,9 +263,9 @@ class HTMLFileBuilder {
   }
 
   // TODO: Could this method send a request to a new API endpoint?
-  async generateLaTeX(html) {
-    return convertText(html);
-  }
+  // async generateLaTeX(html) {
+  //   return convertText(html);
+  // }
 
   async getIndexHTML(withStyles = false, print = false, pdf, subchapterImages, h3=true) {
     const { chapters, condition } = this.data;

--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -3,6 +3,9 @@ import AdmZip from 'adm-zip';
 import { EPubData } from 'entities/EPubs';
 import { doc } from 'prettier';
 import { jsPDF as JsPDF } from "jspdf";
+
+//import { convertText } from 'html-to-latex';
+
 import EPubParser from './EPubParser';
 import { KATEX_MIN_CSS, PRISM_CSS } from './file-templates/styles';
 import {
@@ -70,7 +73,7 @@ class HTMLFileBuilder {
           } else if (value === true && (chapters[i].condition && chapters[i].condition.find(elem => elem === key) !== undefined)) {
               selectedChapters.push(chapters[i]);
               break;
-            }  
+            }
         }
       }
       selectedChapters.forEach(chapter => {
@@ -109,160 +112,187 @@ class HTMLFileBuilder {
       });
   }
 
-  getIndexHTML(withStyles = false, print = false, pdf, subchapterImages, h3=true) {
-    const { title, author, chapters, cover } = this.data;
-    const margin = 10;
-    let w = pdf.internal.pageSize.getWidth() - 2*margin;
-    let h = pdf.internal.pageSize.getHeight() - 2*margin;
-    let selectedChapters = [];
-    for (let i = 0; i < chapters.length; i+= 1) {
-      for (const [key, value] of Object.entries(this.data.condition)) {
-        if (key === 'default') {
-          if (value === true && (!chapters[i].condition || chapters[i].condition.find(elem => elem === key) !== undefined)) {
-            selectedChapters.push(chapters[i]);
-            break;
+  generatePDF(epub, pdf, subchapterImages, selectedChapters) {
+      const { title, author, cover } = epub;
+      const margin = 10;
+      let w = pdf.internal.pageSize.getWidth() - 2*margin;
+      let h = pdf.internal.pageSize.getHeight() - 2*margin;
+      // this.prefetchSubchapterImages(chapters);
+      // console.log(w);
+      // console.log(h);
+      // console.log(cover);
+      let metadata = `<rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title><rdf:Alt><rdf:li xml:lang="x-default">${ title }</rdf:li></rdf:Alt></dc:title> </rdf:Description>`;
+      // metadata = metadata + '<rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier>' + title +'</dc:identifier> </rdf:Description>';
+      pdf.addMetadata(metadata,"http://ns.adobe.com/pdf/1.3/");
+      pdf.setProperties({title, author});
+      pdf.setFont("times", "normal");
+      pdf.addImage(cover.src,'JPEG', 25, 0, 160,100);
+      pdf.text(title, w/2,130, 'center');
+      pdf.text(author, w/2,140,'center');
+      pdf.addPage();
+
+
+
+      // console.log(navContents);
+      selectedChapters.forEach((chapter, i) => {
+          let curText = chapter.text;
+          pdf.text(`${i+1} ${chapter.title}`, margin, 10, 'left');
+          let pageCurrent = pdf.internal.getCurrentPageInfo().pageNumber;
+          pdf.outline.add(null, chapter.title, {pageNumber:pageCurrent});
+          let imgStart = curText.indexOf("src=");
+          let imgEnd = curText.indexOf("alt=");
+          let imgData = curText.substring(imgStart+5, imgEnd-2);
+          pdf.addImage(imgData, 'JPEG', 15, 20, 180, 100);
+          // pdf.text("Transcript", 0, 130, 'left');
+          let transcriptStart = curText.indexOf("<p>");
+          let transcriptEnd = curText.indexOf("</p>");
+          let y = 140;
+          if (transcriptStart !== -1) {
+              let transcript = curText.substring(transcriptStart+3, transcriptEnd);
+              let splitted = pdf.splitTextToSize(transcript, parseInt(w,10));
+              splitted.forEach(splitval => {
+                  if (y >= h-h%10) {
+                      y = 10;
+                      pdf.addPage();
+                  }
+                  pdf.text(splitval, margin, y);
+                  y += 10;
+              });
           }
-        } else if (value === true && (chapters[i].condition && chapters[i].condition.find(elem => elem === key) !== undefined)) {
-            selectedChapters.push(chapters[i]);
-            break;
-          }  
-      }
-    }
-    // this.prefetchSubchapterImages(chapters);
-        // console.log(w);
-        // console.log(h);
-        // console.log(cover);
-        let metadata = `<rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title><rdf:Alt><rdf:li xml:lang="x-default">${ title }</rdf:li></rdf:Alt></dc:title> </rdf:Description>`;
-        // metadata = metadata + '<rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier>' + title +'</dc:identifier> </rdf:Description>';
-        pdf.addMetadata(metadata,"http://ns.adobe.com/pdf/1.3/");
-        pdf.setProperties({title, author});
-        pdf.setFont("times", "normal");
-        pdf.addImage(cover.src,'JPEG', 25, 0, 160,100);
-        pdf.text(title, w/2,130, 'center');
-        pdf.text(author, w/2,140,'center');
-        pdf.addPage();
-        let navContents = _.map(
-            selectedChapters,
-            (ch, chIndex) => `
+          // eslint-disable-next-line no-unused-expressions
+          chapter?.subChapters?.forEach((subchapter, j) => {
+              // Print each subchapter on new page
+              pdf.addPage();
+              y = 10;
+              pdf.text(`${i+1}-${j+1} ${subchapter.title}`, margin, y, 'left');
+              y += 10;
+
+              // Add subchapter to outline
+              pdf.outline.add(null, subchapter.title, {pageNumber:pageCurrent});
+
+              // Parse subchapter contents to produce transcript of text
+              // eslint-disable-next-line no-unused-expressions
+              subchapter?.contents?.forEach(subContents => {
+                  if (typeof subContents === 'string') {
+                      // Add subchapter transcript
+                      let transcript = subContents.replace('#### Transcript', '');
+                      let splitted = pdf.splitTextToSize(transcript, parseInt(w,10));
+                      splitted.forEach(splitval => {
+                          if (y >= h-h%10) {
+                              y = 10;
+                              pdf.addPage();
+                          }
+                          pdf.text(splitval, margin, y);
+                          y += 10;
+                      });
+                  } else if (subContents.src) {
+                      const subImgData = subchapterImages[subContents.src];
+
+                      // If image was prefetched, insert it here
+                      pdf.addImage(subImgData, 'JPEG', 15, 20, 180, 100);
+
+                      y = 140;
+                  }
+              });
+          });
+
+          if (i !== selectedChapters.length-1) {
+              pdf.addPage();
+          }
+      });
+
+      return pdf;
+  }
+
+  generateHTML(epub, selectedChapters, withStyles = false, print = false, h3=true) {
+      const { title, cover, author } = epub;
+      let navContents = _.map(
+          selectedChapters,
+          (ch, chIndex) => `
           <h3><a href="#${ch.id}">${chIndex + 1} - ${ch.title}</a></h3>
           <ol>
               ${_.map(
-                ch.subChapters,
-                (subch, subIndex) =>`
+              ch.subChapters,
+              (subch, subIndex) =>`
             <li>
               <a href="#${subch.id}">${chIndex + 1}.${subIndex + 1} - ${subch.title}</a>
             </li>`,).join('\n')}
           </ol>
       `,
-        ).join('\n');
-        if (!h3) {
+      ).join('\n');
+      if (!h3) {
           navContents = _.map(
-            selectedChapters,
-            (ch, chIndex) => `
+              selectedChapters,
+              (ch, chIndex) => `
           <h4><a href="#${ch.id}">${chIndex + 1} - ${ch.title}</a></h4>
           <ol>
               ${_.map(
-                ch.subChapters,
-                (subch, subIndex) =>`
+                  ch.subChapters,
+                  (subch, subIndex) =>`
             <li>
               <a href="#${subch.id}">${chIndex + 1}.${subIndex + 1} - ${subch.title}</a>
             </li>`,).join('\n')}
           </ol>
       `,
-        ).join('\n');
-        }
+          ).join('\n');
+      }
 
-
-        // console.log(navContents);
-        selectedChapters.forEach((chapter, i) => {
-            let curText = chapter.text;
-            pdf.text(`${i+1} ${chapter.title}`, margin, 10, 'left');
-            let pageCurrent = pdf.internal.getCurrentPageInfo().pageNumber;
-            pdf.outline.add(null, chapter.title, {pageNumber:pageCurrent});
-            let imgStart = curText.indexOf("src=");
-            let imgEnd = curText.indexOf("alt=");
-            let imgData = curText.substring(imgStart+5, imgEnd-2);
-            pdf.addImage(imgData, 'JPEG', 15, 20, 180, 100);
-            // pdf.text("Transcript", 0, 130, 'left');
-            let transcriptStart = curText.indexOf("<p>");
-            let transcriptEnd = curText.indexOf("</p>");
-            let y = 140;
-            if (transcriptStart !== -1) {
-                let transcript = curText.substring(transcriptStart+3, transcriptEnd);
-                let splitted = pdf.splitTextToSize(transcript, parseInt(w,10));
-                splitted.forEach(splitval => {
-                    if (y >= h-h%10) {
-                        y = 10;
-                        pdf.addPage();
-                    }
-                    pdf.text(splitval, margin, y);
-                    y += 10;
-                });
-            }
-            // eslint-disable-next-line no-unused-expressions
-            chapter?.subChapters?.forEach((subchapter, j) => {
-                // Print each subchapter on new page
-                pdf.addPage();
-                y = 10;
-                pdf.text(`${i+1}-${j+1} ${subchapter.title}`, margin, y, 'left');
-                y += 10;
-
-                // Add subchapter to outline
-                pdf.outline.add(null, subchapter.title, {pageNumber:pageCurrent});
-
-                // Parse subchapter contents to produce transcript of text
-                // eslint-disable-next-line no-unused-expressions
-                subchapter?.contents?.forEach(subContents => {
-                    if (typeof subContents === 'string') {
-                        // Add subchapter transcript
-                        let transcript = subContents.replace('#### Transcript', '');
-                        let splitted = pdf.splitTextToSize(transcript, parseInt(w,10));
-                        splitted.forEach(splitval => {
-                            if (y >= h-h%10) {
-                                y = 10;
-                                pdf.addPage();
-                            }
-                            pdf.text(splitval, margin, y);
-                            y += 10;
-                        });
-                    } else if (subContents.src) {
-                        const subImgData = subchapterImages[subContents.src];
-
-                        // If image was prefetched, insert it here
-                        pdf.addImage(subImgData, 'JPEG', 15, 20, 180, 100);
-
-                        y = 140;
-                    }
-                });
-            });
-
-            if (i !== selectedChapters.length-1) {
-                pdf.addPage();
-            }
-        });
-
-        const content = _.map(
-            selectedChapters,
-            (ch) => `
+      const content = _.map(
+          selectedChapters,
+          (ch) => `
         <div class="ee-preview-text-con">
           ${ch.text/** .replace(/\n/g, '\n\t\t\t\t\t') */}
         </div>
         ${_.map(ch.subChapters, (subCh) =>
-                _.map(subCh.contents, (contents) => (typeof contents === 'string') ? `
+              _.map(subCh.contents, (contents) => (typeof contents === 'string') ? `
             <div class="ee-preview-text-con">
               ${contents.substring(16)}
             </div>
           ` : ``).join('\n')
-            ).join('\n')}
+          ).join('\n')}
       `
-        ).join('\n');
+      ).join('\n');
 
-        // console.log(content);
-        print = print && typeof print === 'boolean';
 
-        return withStyles
-            ? INDEX_HTML_LIVE({ title, navContents, content, cover, author, print })
-            : INDEX_HTML_LOCAL({ title, navContents, content, author });
+      // console.log(content);
+      print = print && typeof print === 'boolean';
+
+      return withStyles
+          ? INDEX_HTML_LIVE({ title, navContents, content, cover, author, print })
+          : INDEX_HTML_LOCAL({ title, navContents, content, author });
+  }
+
+  // TODO: Could this method send a request to a new API endpoint?
+  async generateLaTeX(html) {
+    return convertText(html);
+  }
+
+  async getIndexHTML(withStyles = false, print = false, pdf, subchapterImages, h3=true) {
+    const { chapters, condition } = this.data;
+
+      let selectedChapters = [];
+      for (let i = 0; i < chapters.length; i+= 1) {
+          for (const [key, value] of Object.entries(condition)) {
+              if (key === 'default') {
+                  if (value === true && (!chapters[i].condition || chapters[i].condition.find(elem => elem === key) !== undefined)) {
+                      selectedChapters.push(chapters[i]);
+                      break;
+                  }
+              } else if (value === true && (chapters[i].condition && chapters[i].condition.find(elem => elem === key) !== undefined)) {
+                  selectedChapters.push(chapters[i]);
+                  break;
+              }
+          }
+      }
+      this.generatePDF(this.data, pdf, subchapterImages, selectedChapters);
+      const html = this.generateHTML(this.data, selectedChapters, withStyles, print, h3);
+
+      // TODO: How can we return/download this generated LaTeX source?
+      // FIXME: No frontend bundle for `html-to-latex` (expects OS-native NodeJS calls)
+      // TODO: To test, uncomment this line and run `yarn add html-to-latex http2` and `yarn install`
+      // const latex = await this.generateLaTeX(html)
+
+      return html
   }
 
   async getHTMLBuffer(h3) {

--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -4,7 +4,7 @@ import { EPubData } from 'entities/EPubs';
 import { doc } from 'prettier';
 import { jsPDF as JsPDF } from "jspdf";
 
-//import { convertText } from 'html-to-latex';
+// import { convertText } from 'html-to-latex';
 
 import EPubParser from './EPubParser';
 import { KATEX_MIN_CSS, PRISM_CSS } from './file-templates/styles';


### PR DESCRIPTION
Added some notes about a few possible ideas / patterns for converting to LaTeX. The idea is mostly just an idea for now, but the comments and this document are left to indicate possible places that we can go with it


#### Option 1: perform the conversion using a new API endpoint (this would be my recommendation)
By adding one or more new API endpoints, it would be trivial to convert to this or any other arbitrary format. It is also possible that support for converting to these well-known formats may already exist in both C# and Python.

Adding a new endpoint for each one provides a declarative way to approach the API: e.g. prefer `/api/EPubs/{id}/pdf` and `/api/EPubs/{id}/latex` vs `/api/EPubs/{id}/convert?format=pdf`

The former is more clear and explicit, whereas the latter has inherent logic gaps - e.g. what happens if we don't provide a format in the latter case? this would be impossible in the case of the former

#### Option 2: convert everything to LaTeX in the frontend (in the user's browser)
Using a simple conversion script, we can transform HTML source into LaTeX source. See https://github.com/jdalrymple/html-to-latex for an example

Note that `html-to-latex` works in a simple scripting example, but when attempting to run it as a browser package the compiler complains about missing OS-native support for NodeJS. We would need to rewrite/tweak/modify this behavior to allow the package to be imported into a browser (and not depend on native things like `fs-events`, which may not be available in a browser environment)

We could choose to modify the existing `html-to-latex` example to work for our case, or write our own simple converter to cover base cases. Note that we would **not** be addressing complex cases like generating LaTeX formulas or dynamic HTML content - we only need a simple conversion from structural HTML elements into structural LaTeX elements 

For example:
* `<h1>` => `\section`
* `<h2>` => `\subsection`
* `<h3>` or `<h4>` => `\subsubsection`
* `<h5>` => `\paragraph`
* `<h6>` => `\subparagraph`

For a `sed` script containing more individual/specific replacements, see https://tex.stackexchange.com/a/269103

#### Option 3: instruct the user to use third-party utilities

We could direct the user to download a native third-party utility (e.g. Pandoc or similar) to perform less commonly utilized conversions. This would provide wider support by providing no support, which works but is also less than ideal

For example: user could download EPub as HTML and run `pandoc  --standalone index.html --output index.tex`

There may be other options available as well, which are open for discussion