### PR TITLE
Scrub issue fix

### DIFF
--- a/src/screens/Watch/Components/Transcriptions/CaptionLine/index.js
+++ b/src/screens/Watch/Components/Transcriptions/CaptionLine/index.js
@@ -24,7 +24,8 @@ function CaptionLine({ isCurrent = false, isEditing = false,
   };
 
   const handleSeek = () => {
-    const time = timeStrToSec(startTime);
+    const time = timeStrToSec(begin);
+    console.log(begin)
     dispatch({ type: 'watch/media_setCurrTime', payload: time })
   };
 

--- a/src/screens/Watch/Components/Transcriptions/CaptionLine/index.js
+++ b/src/screens/Watch/Components/Transcriptions/CaptionLine/index.js
@@ -25,7 +25,6 @@ function CaptionLine({ isCurrent = false, isEditing = false,
 
   const handleSeek = () => {
     const time = timeStrToSec(begin);
-    console.log(begin)
     dispatch({ type: 'watch/media_setCurrTime', payload: time })
   };
 


### PR DESCRIPTION
Issue was originally brought up by Justin. Conflicting types between the Live Player and the Video player led to start being undefined when the normal player was in use. This causes the video to scrub to the beginning when a caption time stamp is clicked due to NAN.This correctly switches it to begin which is valid in both instances.