### PR TITLE
fix latex output to include subchapters and subchapter images

### DIFF
--- a/src/screens/EPub/controllers/file-builders/ScreenshotsBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/ScreenshotsBuilder.js
@@ -66,7 +66,13 @@ class ScreenshotsBuilder {
         let subContent = `\\subsection{${subChapter.title}}`;
         for (let k = 0; k < subChapter.contents.length; k += 1) {
           let subContents = subChapter.contents[k];
+          // unwrap __data__ for correct image loading in subchapters 
+          if (typeof subContents === 'object' && "__data__" in subContents) {
+            subContents = JSON.parse(JSON.stringify(subContents.__data__));
+          }
           if (typeof subContents === 'string') {
+            subContents = subContents.replace('#### Transcript', '');
+            subContents = subContents.trim(); 
             subContents = subContents.replaceAll("%", "\\%");
             subContent = subContent.concat(subContents, '\n');
           } else if (subContents.src) {
@@ -75,6 +81,7 @@ class ScreenshotsBuilder {
             subContent = subContent.concat(imageInfo);
           }
         }
+        chapterContent = chapterContent.concat(subContent, '\\newpage\n');
       }
       content = content.concat(chapterContent, '\\newpage\n');
     }


### PR DESCRIPTION
Same issue and fix as HTML and EPUB file builders where the format we receive data in from the backend was not handled correctly in the frontend 

Also I know we are trying to move away from string searching but I wanted to push this fix in the meantime until we come up with a standardized way of parsing the HTML.  
