### PR TITLE
Fix crash in QuickActions 

### DIFF
--- a/src/entities/EPubs/structs/EPubChapterData.js
+++ b/src/entities/EPubs/structs/EPubChapterData.js
@@ -2,7 +2,7 @@ import { buildHTMLFromChapter } from '../html-converters';
 import EPubChapterLikeData from './EPubChapterLikeData';
 import EPubSubChapterData from './EPubSubChapterData';
 
-let untitledChapterNum = -1;
+let untitledChapterNum = 0;
 function _createChapterTitle() {
   untitledChapterNum += 1;
   let chapterNum = untitledChapterNum > 0 ? ` (${untitledChapterNum})` : '';

--- a/src/entities/EPubs/structs/EPubSubChapterData.js
+++ b/src/entities/EPubs/structs/EPubSubChapterData.js
@@ -1,8 +1,15 @@
 import EPubChapterLikeData from './EPubChapterLikeData';
 
+let untitledSubChapterNum = 0;
+function _createSubChapterTitle() {
+  untitledSubChapterNum += 1;
+  let chapterNum = untitledSubChapterNum > 0 ? ` (${untitledSubChapterNum})` : '';
+  return `Untitled Sub-Chapter${chapterNum}`;
+}
+
 class EPubSubChapterData extends EPubChapterLikeData {
   constructor(subChapterLike, resetText) {
-    super(subChapterLike, resetText, () => 'Untitled Sub-Chapter');
+    super(subChapterLike, resetText, _createSubChapterTitle);
   }
 
   toObject() {

--- a/src/screens/EPub/views/EditEPubStructure/ChapterList/EPubChapterItem.js
+++ b/src/screens/EPub/views/EditEPubStructure/ChapterList/EPubChapterItem.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import cx from 'classnames';
 import { CTText } from 'layout';
 import { ChapterTitle } from '../../../components';
@@ -40,7 +40,15 @@ function EPubChapterItem({
 
   const chClasses = cx('ct-epb', 'sch', 'ch-item', 'ct-d-c', { fold: isFolded });
 
-  const itemsToDisplay = canDisplayFull ? chapter.items : chapter.items.slice(0, 3)
+  const itemsToDisplay = canDisplayFull ? chapter.items : chapter.items.slice(0, 3);
+
+  // Automatically update the untitled chapter names to correlate with the chapter index
+  useEffect(() => {
+    const reg = /^Untitled Chapter \(\d\)$/;
+    if (reg.test(chapter.title)) {
+      saveChapterTitle(`Untitled Chapter (${chapterIndex + 1})`)
+    }
+  }, [chapterIndex]);
 
   return (
     <div

--- a/src/screens/EPub/views/EditEPubStructure/ChapterList/EPubSubChapterItem.js
+++ b/src/screens/EPub/views/EditEPubStructure/ChapterList/EPubSubChapterItem.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import cx from 'classnames';
 import { CTText } from 'layout';
 import { epub, getCompactText } from '../../../controllers';
@@ -49,6 +49,14 @@ function EPubSubChapterItem({
   const schClasses = cx('ct-epb', 'sch', 'ch-item', 'sub', 'ct-d-c', {
     fold: isFolded
   });
+
+  // Automatically update the untitle subchapter names to correlate with the subchapter index
+  useEffect(() => {
+    const reg = /^Untitled Sub-Chapter \(\d\)$/;
+    if (reg.test(subChapter.title)) {
+      saveSubChapterTitle(`Untitled Sub-Chapter (${subChapterIndex + 1})`)
+    }
+  }, [subChapterIndex]);
 
   return (
     <div id={epub.id.schID(subChapter.id)} className={schClasses}>

--- a/src/screens/EPub/views/EditEPubStructure/QuickActions.js
+++ b/src/screens/EPub/views/EditEPubStructure/QuickActions.js
@@ -10,11 +10,7 @@ import { epub as epubOld } from '../../controllers';
 function QuickActions({ chapters = {}, items, currChIndex = 0, dispatch }) {
   const btnStyles = useButtonStyles();
   const btnClasses = cx(btnStyles.tealLink, 'justify-content-start');
-  console.log("test");
-  if (currChIndex >= chapters.length) {
-    console.log("HERE", currChIndex);
-    currChIndex--; 
-  }
+  if (currChIndex >= chapters.length) {currChIndex = 0;}
   const { start, end, title } = chapters[currChIndex];
   const startTimeStr = timestr.toPrettierTimeString(start);
   const endTimeStr = timestr.toPrettierTimeString(end);

--- a/src/screens/EPub/views/EditEPubStructure/QuickActions.js
+++ b/src/screens/EPub/views/EditEPubStructure/QuickActions.js
@@ -10,6 +10,11 @@ import { epub as epubOld } from '../../controllers';
 function QuickActions({ chapters = {}, items, currChIndex = 0, dispatch }) {
   const btnStyles = useButtonStyles();
   const btnClasses = cx(btnStyles.tealLink, 'justify-content-start');
+  console.log("test");
+  if (currChIndex >= chapters.length) {
+    console.log("HERE", currChIndex);
+    currChIndex--; 
+  }
   const { start, end, title } = chapters[currChIndex];
   const startTimeStr = timestr.toPrettierTimeString(start);
   const endTimeStr = timestr.toPrettierTimeString(end);


### PR DESCRIPTION
Array out of bounds error occurs when currChIndex gets set to larger than the amount of chapters. Setting it back to its default value of 0 fixes the issue.  