### PR TITLE
add out of bounds check to QuickActions

### DIFF
--- a/src/screens/EPub/views/EditEPubStructure/QuickActions.js
+++ b/src/screens/EPub/views/EditEPubStructure/QuickActions.js
@@ -10,6 +10,7 @@ import { epub as epubOld } from '../../controllers';
 function QuickActions({ chapters = {}, items, currChIndex = 0, dispatch }) {
   const btnStyles = useButtonStyles();
   const btnClasses = cx(btnStyles.tealLink, 'justify-content-start');
+  if (currChIndex >= chapters.length) {currChIndex = 0;}
   const { start, end, title } = chapters[currChIndex];
   const startTimeStr = timestr.toPrettierTimeString(start);
   const endTimeStr = timestr.toPrettierTimeString(end);


### PR DESCRIPTION
Website crash and array out of bounds was occurring when currChIndex gets set to above the number of current chapters. Setting it back to its default value of 0 fixes the issue. 