### PR TITLE
Fixed issue when glossary applies to chapter title

### DIFF
--- a/src/screens/EPub/components/EPubFileInfoModal.js
+++ b/src/screens/EPub/components/EPubFileInfoModal.js
@@ -150,7 +150,7 @@ function EPubFileInfoModal({ showFileSettings, dispatch, epub }) {
         <CTFormRow>
           <CTCheckbox
             id="ct-epb-enable-glossary"
-            label="Disable Glossary"
+            label="Turn off Glossary"
             checked={epubData.disableGlossary}
             onChange={onGlossaryDisable}
           />

--- a/src/screens/EPub/components/EPubFileInfoModal.js
+++ b/src/screens/EPub/components/EPubFileInfoModal.js
@@ -19,6 +19,9 @@ function EPubFileInfoModal({ showFileSettings, dispatch, epub }) {
   if (!epubData.condition) {
     epubData.condition = { default: true };
   }
+  if(!('enableGlossary' in epubData)) {
+    epubData.enableGlossary = true;
+  }
   useEffect(() => {
     // update state everytime onShow, in case the user did not save
     if (showFileSettings) {
@@ -38,8 +41,8 @@ function EPubFileInfoModal({ showFileSettings, dispatch, epub }) {
   const onAllGlossaryTermHighlight = ({ target: { checked } }) =>
     setEPubData({ ...epubData, enableAllGlossaryTermHighlight: checked });
 
-  const onGlossaryDisable = ({ target: { checked } }) =>
-    setEPubData({ ...epubData, disableGlossary: checked });
+  const onGlossaryEnable = ({ target: { checked } }) =>
+    setEPubData({ ...epubData, enableGlossary: checked });
 
   const onPublishChange = ({ target: { checked } }) =>
     setEPubData({ ...epubData, isPublished: checked });
@@ -150,9 +153,9 @@ function EPubFileInfoModal({ showFileSettings, dispatch, epub }) {
         <CTFormRow>
           <CTCheckbox
             id="ct-epb-enable-glossary"
-            label="Turn off Glossary"
-            checked={epubData.disableGlossary}
-            onChange={onGlossaryDisable}
+            label="Include Glossary"
+            checked={epubData.enableGlossary}
+            onChange={onGlossaryEnable}
           />
         </CTFormRow>
         <CTFormRow>

--- a/src/screens/EPub/controllers/file-builders/EPubFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/EPubFileBuilder.js
@@ -305,7 +305,7 @@ class EPubFileBuilder {
       const elements = textHtml.getElementsByTagName("p");
 
       // highlight and generate glossary for text in <p> tags
-      for(let i = 0; i < elements.length; i++) {
+      for(let i = 0; i < elements.length; i+=1) {
         const [highlightedText, currentGlossary] = getChapterGlossaryAndTextHighlight(
           elements[i].innerHTML,
           this.glossaryData,
@@ -317,7 +317,7 @@ class EPubFileBuilder {
 
         // update chapter glossary with words found in current text
         for(const word of Object.keys(currentGlossary)) {
-          if(!chapterGlossary.hasOwnProperty(word)) {
+          if(!(word in chapterGlossary)) {
             chapterGlossary[word] = currentGlossary[word];
           }
         }

--- a/src/screens/EPub/controllers/file-builders/EPubFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/EPubFileBuilder.js
@@ -37,9 +37,9 @@ class EPubFileBuilder {
     this.h3 = ePubData.h3;
 
     // The disable glossary option in the menu is used to hide or show the glossary
-    this.disableGlossary = 'disableGlossary' in this.data ? this.data.disableGlossary : false;
+    this.enableGlossary = 'enableGlossary' in this.data ? this.data.enableGlossary : true;
 
-    if (!this.disableGlossary) {
+    if (this.enableGlossary) {
       // The highlightAll option is used to know whether to highlight the 
       // first occurrence or all occurrences of glossary words in the iNote.
       this.highlightAll =
@@ -52,8 +52,7 @@ class EPubFileBuilder {
       // URL to an external webstie for more information about that word.
       this.glossaryData = await getGlossaryData(this.data.sourceId);
     } else {
-      // When glossary is disabled we do not fetch data or 
-      // highlight any word.
+      // When glossary is disabled we do not fetch data or highlight any word.
       this.highlightAll = false;
       this.glossaryData = {};
     }
@@ -310,7 +309,7 @@ class EPubFileBuilder {
     let content = '';
 
     // check if glossary is enabled
-    if (!this.disableGlossary) {
+    if (this.enableGlossary) {
       // add glossary terms to end of chapter if enabled
       const [highlightedText, chapterGlossary] = getChapterGlossaryAndTextHighlight(
         text,

--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -209,7 +209,7 @@ class HTMLFileBuilder {
       let glossaryText = "";
       
       if (epub.enableGlossary) {
-        const [_, glossary] = getChapterGlossaryAndTextHighlight(chapter.text, this.glossaryData, this.highlightAll);
+        const glossary = getChapterGlossaryAndTextHighlight(chapter.text, this.glossaryData, this.highlightAll)[1];
         glossaryText = glossaryToText(glossary);
       }
 
@@ -259,7 +259,7 @@ class HTMLFileBuilder {
             glossaryText = "";
 
             if(epub.enableGlossary) {
-              const [_, glossary] = getChapterGlossaryAndTextHighlight(transcript, this.glossaryData, this.highlightAll);
+              const glossary = getChapterGlossaryAndTextHighlight(transcript, this.glossaryData, this.highlightAll)[1];
               glossaryText = glossaryToText(glossary);
             }
 

--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -8,7 +8,7 @@ import EPubParser from './EPubParser';
 import { KATEX_MIN_CSS, PRISM_CSS } from './file-templates/styles';
 import {
   getGlossaryData,
-  glossaryTermsAsText,
+  glossaryToText,
   getChapterGlossaryAndTextHighlight,
 } from './GlossaryCreator';
 
@@ -207,16 +207,10 @@ class HTMLFileBuilder {
       // add glossary terms for chapter
 
       let glossaryText = "";
-      let glossaryTerms = null;
       
       if (epub.enableGlossary) {
-        glossaryTerms = getChapterGlossaryAndTextHighlight(
-          chapter.text,
-          this.glossaryData,
-          this.highlightAll,
-        )[1];
-
-        glossaryText = glossaryTermsAsText(glossaryTerms);
+        const [_, glossary] = getChapterGlossaryAndTextHighlight(chapter.text, this.glossaryData, this.highlightAll);
+        glossaryText = glossaryToText(glossary);
       }
 
       let splitted = pdf.splitTextToSize(glossaryText, parseInt(w, 10));
@@ -262,17 +256,11 @@ class HTMLFileBuilder {
             }
 
             // add glossary terms for subchapter
-
             glossaryText = "";
 
             if(epub.enableGlossary) {
-              glossaryTerms = getChapterGlossaryAndTextHighlight(
-                transcript,
-                this.glossaryData,
-                true,
-              )[1];
-
-              glossaryText = glossaryTermsAsText(glossaryTerms);
+              const [_, glossary] = getChapterGlossaryAndTextHighlight(transcript, this.glossaryData, this.highlightAll);
+              glossaryText = glossaryToText(glossary);
             }
 
             let subSplitted = pdf.splitTextToSize(glossaryText, parseInt(w, 10));

--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -209,7 +209,7 @@ class HTMLFileBuilder {
       let glossaryText = "";
       let glossaryTerms = null;
       
-      if (!epub.disableGlossary) {
+      if (epub.enableGlossary) {
         glossaryTerms = getChapterGlossaryAndTextHighlight(
           chapter.text,
           this.glossaryData,
@@ -265,7 +265,7 @@ class HTMLFileBuilder {
 
             glossaryText = "";
 
-            if(!epub.disableGlossary) {
+            if(epub.enableGlossary) {
               glossaryTerms = getChapterGlossaryAndTextHighlight(
                 transcript,
                 this.glossaryData,


### PR DESCRIPTION
- Epub glossary only applies to text in `<p>` tags