### PR TITLE
style change for popup and asl video

### DIFF
--- a/src/screens/Asl/components/AslTable/index.js
+++ b/src/screens/Asl/components/AslTable/index.js
@@ -55,6 +55,7 @@ const AslTable = props => {
     const [onePage, setOnePage] = useState([]);
     const [showVideo, setShowVideo] = useState(false);
     const [videoUrl, setVideoUrl] = useState('');
+    const [selectedTerm, setSelectedTerm] = useState(null);
     const [style, setStyle] = useState({
         left: 100,
         top: 100,
@@ -71,7 +72,7 @@ const AslTable = props => {
     })
     const [isDown, setIsDown] = useState(false);
     const [direction, setDirection] = useState('');
-
+    
     useEffect(() => {
       const index = (pageNumber-1) * ONE_PAGE_NUM;
       setOnePage(items.filter(item => item.term.toLowerCase().includes(search.toLowerCase())).slice(index, index + ONE_PAGE_NUM));
@@ -117,7 +118,10 @@ const AslTable = props => {
       return 'Example'
     }
 
-    const handleVideo = (source, uniqueASLIdentifier) => {
+    const handleVideo = (term) => {
+      setSelectedTerm(term);
+      const source = term.source;
+      const uniqueASLIdentifier = term.uniqueASLIdentifier;
       const hostName = window.location.hostname;
       if (hostName !== '') {
         if (source === 'ASLCORE') {
@@ -227,9 +231,10 @@ const AslTable = props => {
               onClick={() => setShowVideo(false)}
             >X
             </button>
-
+            <span>{`${selectedTerm.term} (Source:${selectedTerm.source})`}</span>
             <video 
-              className="video-js vjs-default-skin video-player" 
+              className="video-js vjs-default-skin video-player"
+              id="ASL-Glossary-video-player" 
               controls
               preload="auto"
               data-setup="{}"
@@ -319,7 +324,7 @@ const AslTable = props => {
                   <td>
                     <button 
                       type='button' 
-                      onClick={() => handleVideo(term.source, term.uniqueASLIdentifier)}
+                      onClick={() => handleVideo(term)}
                     >
                       Watch
                     </button>

--- a/src/screens/Asl/components/AslTable/index.scss
+++ b/src/screens/Asl/components/AslTable/index.scss
@@ -96,9 +96,10 @@ tbody tr:hover {
     position: absolute;
 }
 
-.video-player {
+#ASL-Glossary-video-player{
+    margin-top: 33px;
     width: 100%;
-    height: 100%;
+    height: 84%;
 }
 
 .drawing-wrap{
@@ -110,12 +111,21 @@ tbody tr:hover {
     // cursor: move;
     width: 100px;
     height: 100px;
-    background-color: #ccc;
+    background-color: rgb(2, 50, 64);
     position: absolute;
     top: 100px;
     left: 100px;
     box-sizing: border-box;
 
+}
+
+.drawing-item span{
+    color: white;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: larger;
+    margin-top: 5px;
 }
 .control-point {
   position: absolute;

--- a/src/screens/Watch/Components/CTPopup/CTPopup.jsx
+++ b/src/screens/Watch/Components/CTPopup/CTPopup.jsx
@@ -10,6 +10,24 @@ import './CTPopup.scss'
 import GlossaryPanel from './GlossaryPanel';
 
 
+
+const ASLVideoPlayer = (word, videoURL, source) => {
+  return (
+    <TabPanel>
+      <strong>{`${word} (Source: ${source})`}</strong><br></br><br></br>
+      {videoURL==='' ? (<span>video not found</span>) 
+      : 
+      (<video 
+        className="video-js vjs-default-skin video-player" 
+        controls
+        preload="auto"
+        data-setup="{}"
+      >
+        <source src={videoURL} type='video/mp4' />
+      </video>)}
+    </TabPanel>)
+}
+
 const CTPopup = ({ time = 0, duration = 0, liveMode = false }) => {
     const [opvalue, setOpvalue] = useState(0.75); // variable for transparency
     const OPSTEP = 0.125; //the amount of changed opvalue for each operation
@@ -191,48 +209,9 @@ const CTPopup = ({ time = 0, duration = 0, liveMode = false }) => {
                         {definitionURL !== '' && (<Tab>Definition</Tab>)}
                         {exampleURL !== '' && (<Tab>Example</Tab>)}
                       </TabList>
-                      {signURL !== '' && (
-                        <TabPanel>
-                          <strong>{term.word}</strong><br></br><br></br>
-                          {signURL==='' ? (<span>sign video for this term is not found</span>) 
-                          : 
-                          (<video 
-                            className="video-js vjs-default-skin video-player" 
-                            controls
-                            preload="auto"
-                            data-setup="{}"
-                          >
-                            <source src={signURL} type='video/mp4' />
-                          </video>)}
-                        </TabPanel>)}
-                      {definitionURL !== '' && (
-                        <TabPanel>
-                          <strong>{term.word}</strong><br></br><br></br>
-                          {definitionURL==='' ? (<span>definition video for this term is not found</span>) 
-                          : 
-                          (<video 
-                            className="video-js vjs-default-skin video-player" 
-                            controls
-                            preload="auto"
-                            data-setup="{}"
-                          >
-                            <source src={definitionURL} type='video/mp4' />
-                          </video>)}
-                        </TabPanel>)}
-                      {exampleURL !== '' && (
-                        <TabPanel>
-                          <strong>{term.word}</strong><br></br><br></br>
-                          {exampleURL==='' ? (<span>example video for this term is not found</span>) 
-                          : 
-                          (<video 
-                            className="video-js vjs-default-skin video-player" 
-                            controls
-                            preload="auto"
-                            data-setup="{}"
-                          >
-                            <source src={exampleURL} type='video/mp4' />
-                          </video>)}
-                        </TabPanel>)}
+                      {signURL !== '' && ASLVideoPlayer(term.word, signURL, term.source)}
+                      {definitionURL !== '' && ASLVideoPlayer(term.word, definitionURL, term.source)}
+                      {exampleURL !== '' && ASLVideoPlayer(term.word, exampleURL, term.source)}
                     </Tabs>
                   </TabPanel>
                   <TabPanel className='divPanel'>

--- a/src/screens/Watch/Components/CTPopup/CTPopup.scss
+++ b/src/screens/Watch/Components/CTPopup/CTPopup.scss
@@ -65,7 +65,7 @@
 
 .glossary-entry {
   list-style: none;
-  color:white;
+  color:rgb(169, 169, 169);
   padding-bottom: 3px;
   overflow-x: hidden;
 }
@@ -77,19 +77,21 @@
 
 .glossary-entry button:focus {
   outline-style: none;
-  text-decoration: underline;
+  font-size: larger;
 }
 
 .glossary-entry-highlighted {
-  color:red;
+  font-weight: bold;
+  color:rgb(255, 255, 255);
 }
 
 .glossary-entry-highlighted button {
   background-color: rgb(2, 50, 64);
 }
 
-.nowrap {
+.divPanel span {
   word-wrap: break-word;
+  width: 280px;
 }
 
 


### PR DESCRIPTION
* fix wrap for explanation of term
* heightlighted words will be bold and white color instead of red
* selected words will have larger font size instead of underline
* ASL video title for glossary table and popup will be "{term} (Source: {source})"