### PR TITLE
Rearange toolbar buttons in i-note editor

### DIFF
--- a/src/screens/EPub/components/EPubHeader/EPubTitle.js
+++ b/src/screens/EPub/components/EPubHeader/EPubTitle.js
@@ -3,7 +3,7 @@ import { CTHeading, CTFragment,useCTConfirmation } from 'layout';
 import { connectWithRedux } from '../../controllers';
 import EPubCopyModal from '../EPubCopyModal';
 import SaveStatusLabel from './SaveStatusLabel';
-import { _makeTBtn } from './ToolButton';
+import { ToolButtonDivider, _makeTBtn } from './ToolButton';
 
 function EPubTitle({ epub, dispatch }) {
   const { title } = epub;
@@ -11,11 +11,6 @@ function EPubTitle({ epub, dispatch }) {
   const onOpenCpyMdl = () => setShowCpyMdl(true);
   const onCloseCpyMdl = () => setShowCpyMdl(false);
   
-  const onOpenSettings = () => dispatch({ type: 'epub/setShowFileSettings', payload: true });
-
-  const settingsBtn = _makeTBtn(
-    'edit', 'Edit file', null, onOpenSettings, false, true
-  );
   const copyBtn = _makeTBtn(
     'file_copy', 'Make a copy', null, onOpenCpyMdl, false, true
   );
@@ -30,7 +25,8 @@ function EPubTitle({ epub, dispatch }) {
     'delete', 'Delete', null, delConfirmation.onOpen, false, true
   );
 
-
+  const saveEPub = () => dispatch({ type: 'epub/updateEPub_Internal' })
+  const saveBtnEl = _makeTBtn('cloud_upload', 'Save', '⌘S', saveEPub, false, true);
 
   return (
     <CTFragment dFlex alignItCenter className="ct-epb header-title con">
@@ -38,9 +34,10 @@ function EPubTitle({ epub, dispatch }) {
         {title}
       </CTHeading>
       <CTFragment dFlex alignItCenter width="max-content">
-        {settingsBtn}
+        <ToolButtonDivider />
         {copyBtn}
         {deleteBtn}
+        {saveBtnEl}
         <SaveStatusLabel />
       </CTFragment>
 

--- a/src/screens/EPub/components/EPubHeader/EPubToolbar.js
+++ b/src/screens/EPub/components/EPubHeader/EPubToolbar.js
@@ -53,12 +53,17 @@ function EPubToolbar({ view, dispatch, epub }) {
     'help_outline', 'Show Help Guide', null, openHelpGuide, false, true
   );
 
+  const onOpenSettings = () => dispatch({ type: 'epub/setShowFileSettings', payload: true });
+
+  const settingsBtn = _makeTBtn(
+    'edit', 'Edit I-Note Info', null, onOpenSettings, false, true
+  );
 
   return (
     <CTFragment id="ct-epb-header-toolbar" justConBetween>
       <CTFragment alignItCenter className="ct-epb tool-btns">
-        {saveBtnEl}
         {null && previewBtnEl} {/* The preview button causes a crash when clicked (cause unknown) */}
+        {settingsBtn}
         <ToolButtonDivider />
         <DownloadDropdown />
         {!isReadOnly && <ToolButtonDivider />}

--- a/src/screens/EPub/components/EPubHeader/ViewDropdown.js
+++ b/src/screens/EPub/components/EPubHeader/ViewDropdown.js
@@ -30,7 +30,7 @@ function ViewDropdown({ view, dispatch }) {
     },
     {
       value: epub.const.EditINote,
-      text: 'Edit INote (beta)',
+      text: 'Edit I-Note (beta)',
       icon: 'edit'
     }
   ];


### PR DESCRIPTION
- move edit file info button next to download button 
- move save button up one level next to save status indicator
<img width="365" alt="image" src="https://github.com/classtranscribe/FrontEnd/assets/42523808/0e6b9ad9-cff7-4c2e-95d6-2193eb366d26">
