### PR TITLE
Bugfix: fixed hardcoded frontend hostname

### DIFF
--- a/src/screens/Glossary/components/GlossaryBar/index.js
+++ b/src/screens/Glossary/components/GlossaryBar/index.js
@@ -24,7 +24,7 @@ export default function GlossaryBar({setSelectCourse, setSelectOffering}) {
     const [initialData, setInitialData] = useState([]);
 
     const apiInstance = axios.create({
-        baseURL: 'https://ct-dev.ncsa.illinois.edu',
+        baseURL: window.location.hostname,
         timeout: 1000,
     });
 

--- a/src/screens/Watch/Components/CTPopup/CTPopup.jsx
+++ b/src/screens/Watch/Components/CTPopup/CTPopup.jsx
@@ -31,8 +31,8 @@ const ASLVideoPlayer = (word, videoURL, source) => {
 const CTPopup = ({ time = 0, duration = 0, liveMode = false }) => {
   const [opvalue, setOpvalue] = useState(0.75); // variable for transparency
   const OPSTEP = 0.125; // the amount of changed opvalue for each operation
-  // const hostName = window.location.hostname;
-  const hostName = "ct-dev.ncsa.illinois.edu"; // for local test
+  const hostName = window.location.hostname;
+  // const hostName = "ct-dev.ncsa.illinois.edu"; // for local test
   // below are variables for videos and explanations for chosen glossary
   const [term, setTerm] = useState({
     word: '',


### PR DESCRIPTION
## Problem
- #651 

## Approach
- Replaced all the hardcoded hostnames to `window.location.hostname`, which maps to the hostname of either the staging or the production environment, based on where the image is running.