### PR TITLE
Remediate pico color accessibility

### DIFF
--- a/src/components/stylesheets/general.vars.css
+++ b/src/components/stylesheets/general.vars.css
@@ -10,6 +10,7 @@
   --ct-green-normal: #348b86;
   --ct-green-active: #23a1a1;
   /* Color */
+  --ct-mobile-menu: rgb(209, 209, 209);
   --ct-text-primary: rgb(73, 73, 73);
   --ct-text-primary-light: #4e4e4e;
   --ct-text-title: rgb(37, 113, 116);

--- a/src/layout/CTNavHeader/index.scss
+++ b/src/layout/CTNavHeader/index.scss
@@ -24,6 +24,12 @@
         color: rgb(219, 219, 219);
       }
     }
+
+    /* Fix pico color accessibility until pico v2 */
+    /* https://github.com/picocss/pico/pull/261 */
+    .pbtn-icon {
+      color: var(--ct-mobile-menu);
+    }
   }
 
   &.fixed {

--- a/src/layout/CTNavSidebar/index.scss
+++ b/src/layout/CTNavSidebar/index.scss
@@ -72,6 +72,12 @@
 
     &.ct-nav-dark {
       background-color: rgb(44, 44, 44);
+
+      /* Fix pico color accessibility until pico v2 */
+      /* https://github.com/picocss/pico/pull/261 */
+      .pbtn-icon {
+        color: var(--ct-mobile-menu);
+      }
     }
 
     .ct-nsb-ul {


### PR DESCRIPTION
Since [pico v1 will not receive color accessibility updates](https://github.com/picocss/pico/pull/276#issuecomment-1364941615), here is a local fix until [pico v2](https://github.com/picocss/pico/pull/261).