### PR TITLE
Added latex equations to latex generation, removed from pdf generation

### DIFF
--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -172,6 +172,14 @@ class HTMLFileBuilder {
       // let transcriptStart = curText.indexOf('<p>'); // use DOM
       let transcriptAllPara = Array.prototype.slice.call(currText_dom.getElementsByTagName("p"),0); // gets all paragraph tags
       let combinedImagePara = allImages.concat(transcriptAllPara);
+      
+      // Span tags contain LaTeX, which cannot currently be rendered properly in PDFs. Thus, we remove them
+      let span_tags = Array.prototype.slice.call(currText_dom.getElementsByTagName("span"));
+      for (let span_idx = 0; span_idx < span_tags.length; span_idx+=1) {
+        let curr_span_tag = span_tags[span_idx];
+        curr_span_tag.replaceWith("");
+      }
+
       for(let k = 0; k < combinedImagePara.length; k+=1) {
         let currElement = combinedImagePara[k];
         if(currElement.tagName.toLowerCase() === "img") {

--- a/src/screens/EPub/controllers/file-builders/ScreenshotsBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/ScreenshotsBuilder.js
@@ -57,10 +57,29 @@ class ScreenshotsBuilder {
       // let transcriptStart = chapter.text.indexOf("<p>");
       // let transcriptEnd = chapter.text.indexOf("</p>");
       let all_text = parser.parseFromString(chapter.text, "text/html");
+      
+      // Replace MathML with P tags containing the LaTeX
+      let latex = Array.prototype.slice.call(all_text.getElementsByTagName("span"));
+      for (let latex_idx = 0; latex_idx < latex.length; latex_idx+=1) {
+        let curr_tag = latex[latex_idx];
+        if (curr_tag.getAttribute("title")) {
+          let annotation = `$$${curr_tag.getAttribute("title")}$$`;
+          let new_p_tag = document.createElement('p');
+          new_p_tag.innerHTML = annotation;
+          curr_tag.replaceWith(new_p_tag);
+        } else if (curr_tag.parentElement.tagName === "P") {
+            let annotation = curr_tag.getElementsByTagName("annotation");
+            if (annotation) {
+              annotation = `$${annotation[0].innerHTML}$`;
+              curr_tag.replaceWith(annotation);
+            }
+          } 
+      }
+      
       let all_paragraphs = Array.prototype.slice.call(all_text.getElementsByTagName("p"),0);
       
       for(let ind = 0; ind < all_paragraphs.length; ind+=1) { 
-        let transcript = all_paragraphs[0].innerHTML; // get the inner html of each paragraph transcript
+        let transcript = all_paragraphs[ind].innerHTML; // get the inner html of each paragraph transcript
         transcript = transcript.replaceAll("%", "\\%");
         chapterContent = chapterContent.concat(transcript, '\n');
       }


### PR DESCRIPTION
Connected to issue #727.

- This takes advantage of the DOM parsing to add Latex to Tex files. The raw LaTeX equations are pulled out from the MathML to be included in the TeX file.
- In the case of PDFs, this simply removes the mathML altogether. I created a long writeup in #727 of the different things I've tried throughout the semester to try to correct the issue. While often close, I was never able to get all the features working that are necessary for INotes (most notably images). I'm not sure if this is something that should be prioritized or is worth the effort to fix.