### PR TITLE
Dedupilcate language selector for I-Notes create new epub (Close #800)

### DIFF
--- a/src/components/CTEPubListScreen/components/NewEPubModal.js
+++ b/src/components/CTEPubListScreen/components/NewEPubModal.js
@@ -24,7 +24,8 @@ function NewEPubModal({
   const title = useInput(defaultTitle);
   const language = useInput(LanguageConstants.English);
 
-  const langOptions = languages.map(
+  const uniqueLanguages = [...new Set(languages)]
+  const langOptions = uniqueLanguages.map(
     lang => ({ value: lang, text: LanguageConstants.decode(lang) })
   );
 


### PR DESCRIPTION
Looks like https://github.com/classtranscribe/FrontEnd/issues/800 originated from the source (video id=`31c8ebb3-0708-440c-b2a3-603c307c6ec8`) having multiple english sources and a single one for all other languages.

![image](https://github.com/classtranscribe/FrontEnd/assets/7780198/e23bb4f1-7a58-44d7-bfdc-91c2f8efdbb3)

We get the list from `source.transcriptions` in `EPubListController.getLanguages()`. Getting this list of seemingly duplicate languages is correct but we shouldn't display them differently so I used a Set to dedup the values for the selector. If it makes sense for any other components we can move the logic up if needed too

