### PR TITLE
Add warning ignore in webpack config (Fix: #734)

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -677,6 +677,10 @@ module.exports = function (webpackEnv) {
       // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
       // You can remove this if you don't use Moment.js:
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+
+      // https://github.com/cthackers/adm-zip/issues/242 - original-fs is a dependency required for electron 
+      // that is unfixed in the original repo
+      new webpack.IgnorePlugin(/original-fs/, /adm-zip/),
       // Generate a service worker script that will precache, and keep up to date,
       // the HTML & assets that are part of the webpack build.
       isEnvProduction &&


### PR DESCRIPTION
https://github.com/classtranscribe/FrontEnd/issues/734

Following the still open https://github.com/cthackers/adm-zip/issues/242, I was able to find out that the original-fs [dependency](https://github.com/cthackers/adm-zip/blob/master/util/fileSystem.js#L4) is only needed for electronJS, so it's quite safe to ignore. Thanks to us being able to configure webpack as we want after the `eject`, I just added the ignore through the plugins.

Updating the version to the latest adm-zip (4 years of updates) didn't help, we could do this upgrade anyway, but I don't see any use just yet and we can do that in the future if needed when we have better tests for epub generation.