### PR TITLE
Undo babelJest temp fix

### DIFF
--- a/config/jest/babelTransform.js
+++ b/config/jest/babelTransform.js
@@ -15,7 +15,7 @@ const hasJsxRuntime = (() => {
   }
 })();
 
-module.exports = babelJest.default.createTransformer({
+module.exports = babelJest.createTransformer({
   presets: [
     [
       require.resolve('babel-preset-react-app'),


### PR DESCRIPTION
Thanks to UIUC's own @nwalters512 creating 
https://github.com/jestjs/jest/pull/12399, we don't need to do the `.default` option that we used earlier in https://github.com/classtranscribe/FrontEnd/pull/820 when we had upgraded versions incrementally. 
