### PR TITLE
fixed the i-note download error

### DIFF
--- a/src/screens/EPub/controllers/EPubDownloadController.js
+++ b/src/screens/EPub/controllers/EPubDownloadController.js
@@ -1,11 +1,12 @@
 import download from 'js-file-download';
+import store from 'store';
 import { prompt } from 'utils/prompt';
 import EPubParser from './file-builders/EPubParser';
 import { EPubFileBuilder, HTMLFileBuilder, PDFFileBuilder, LatexFileBuilder } from './file-builders';
 
 const _download = async (Builder, filenameSuffix, options) => {
   options = Builder.getOptions(options);
-  const { epub } = window.temp_app._store.getState();
+  const { epub } = store.getState();
   const filename = epub.epub.filename + filenameSuffix;
   const parsedData = await EPubParser.parse(epub, options);
   const fileBuffer = await Builder.toBuffer(parsedData);


### PR DESCRIPTION
Updated the e-Pub download controller to use the store variable rather than window.tempapp used as a temporary fix previously.