### PR TITLE
Updated links for images in I-Note

### DIFF
--- a/src/entities/EPubs/structs/EPubData.js
+++ b/src/entities/EPubs/structs/EPubData.js
@@ -1,5 +1,4 @@
 /* eslint-disable complexity */
-import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
 import CTError from 'utils/use-error';
 import { buildMDFromChapters } from '../html-converters';
@@ -7,11 +6,13 @@ import EPubChapterData from './EPubChapterData';
 import EPubImageData from './EPubImageData';
 
 /**
- * The error which occurred when the required information 
+ * The error which occurred when the required information
  * for creating an ePub file is invalid
  */
-export const EPubDataValidationError =
-  new CTError('EPubDataValidationError', 'Invalid I-Note data.');
+export const EPubDataValidationError = new CTError(
+  'EPubDataValidationError',
+  'Invalid I-Note data.',
+);
 
 /**
  * The class for an ePub data
@@ -27,7 +28,8 @@ export default class EPubData {
     cover: null,
     chapters: [],
     h3: true,
-    condition: { 'default': true },
+    condition: { default: true },
+    jsonMetadata: {},
   };
 
   /**
@@ -46,10 +48,9 @@ export default class EPubData {
     else if (typeof data === 'object') {
       this.__data__ = {
         ...this.__data__,
-        ...data
+        ...data,
       };
-    }
-    else {
+    } else {
       throw EPubDataValidationError;
     }
 
@@ -73,6 +74,10 @@ export default class EPubData {
       this.h3 = true;
     }
 
+    if (!this.jsonMetadata) {
+      this.jsonMetadata = data.jsonMetadata;
+    }
+
     // set up cover image
     if (!this.cover) {
       this.cover = new EPubImageData();
@@ -83,18 +88,21 @@ export default class EPubData {
 
   initFromRawData(rawEPubData) {
     this.chapters = [
-      new EPubChapterData({
-        title: 'Default Chapter',
-        items: rawEPubData,
-      }, true, this.sourceId).toObject()
+      new EPubChapterData(
+        {
+          title: 'Default Chapter',
+          items: rawEPubData,
+        },
+        true,
+        this.sourceId,
+      ).toObject(),
     ];
     // this.condition = ['default'];
     this.condition.default = true;
-
-    this.items = rawEPubData.map((item) => (EPubImageData.createWithTimestamp(item, this.sourceId)));
+    this.items = rawEPubData.map((item) => EPubImageData.createWithTimestamp(item, this.sourceId));
 
     if (!this.cover.src && this.items.length > 0) {
-      this.cover = { ...this.items[0], descriptions: [], alt: "cover image" };
+      this.cover = { ...this.items[0], descriptions: [], alt: 'cover image' };
     }
   }
 
@@ -205,6 +213,14 @@ export default class EPubData {
     this.__data__.chapters = chapters;
   }
 
+  set jsonMetadata(jsonMetadata) {
+    this.__data__.jsonMetadata = jsonMetadata;
+  }
+
+  get jsonMetadata() {
+    return this.__data__.jsonMetadata;
+  }
+
   /**
    * @returns {EPubChapterData[]}
    */
@@ -216,7 +232,9 @@ export default class EPubData {
     return {
       ...this.__data__,
       cover: this.cover instanceof EPubImageData ? this.cover.toObject() : this.cover,
-      chapters: this.chapters.map(chapter => (chapter instanceof EPubChapterData ? chapter.toObject() : chapter))
+      chapters: this.chapters.map((chapter) =>
+        chapter instanceof EPubChapterData ? chapter.toObject() : chapter,
+      ),
     };
   }
 
@@ -245,24 +263,19 @@ export default class EPubData {
   removeChapter(index) {
     let chapters = this.chapters;
     let chapter = chapters[index];
-    this.chapters = [
-      ...chapters.slice(0, index),
-      ...chapters.slice(index + 1)
-    ];
+    this.chapters = [...chapters.slice(0, index), ...chapters.slice(index + 1)];
 
     return chapter;
   }
 
-
   static create(rawEPubData, data) {
     const newData = new EPubData({
-      ...data
+      ...data,
     });
     newData.initFromRawData(rawEPubData);
 
     return newData;
   }
-
 
   // static copyChapterStructure(rawEPubData, chapters) {
   //   let lastIdx = 0;

--- a/src/screens/EPub/controllers/file-builders/EPubFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/EPubFileBuilder.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import AdmZip from 'adm-zip';
+import PlaylistTypes from 'entities/Playlists/PlaylistTypes';
 import { dedent } from 'dentist';
 import { KATEX_MIN_CSS, PRISM_CSS } from './file-templates/styles';
 import { glossaryToHTMLString } from './GlossaryCreator';
@@ -83,19 +84,18 @@ class EPubFileBuilder {
 
     // IMAGES — add one <item> per embedded image
     if (Array.isArray(this.imageItems) && this.imageItems.length) {
-      const temp = this.imageItems.map(img =>
-        `<item id="${img.id}" href="${img.href}" media-type="${img.mediaType}" />`
-      ).join('\n\t\t');
+      const temp = this.imageItems
+        .map((img) => `<item id="${img.id}" href="${img.href}" media-type="${img.mediaType}" />`)
+        .join('\n\t\t');
       contentItems += `\n\t\t${temp}`;
     }
 
     // content itemrefs
-    let contentItemsRefs = _.map(chapters, (ch) => `<itemref idref="${ch.id}"/>`
-    ).join('\n\t\t');
+    let contentItemsRefs = _.map(chapters, (ch) => `<itemref idref="${ch.id}"/>`).join('\n\t\t');
 
     if (this.glossary && !_.isEmpty(this.glossary) && !this.data.chapterGlossary) {
       contentItems += `<item id="glossary" href="glossary.xhtml" media-type="application/xhtml+xml" />`;
-      contentItemsRefs += `<itemref idref="glossary"/>`
+      contentItemsRefs += `<itemref idref="glossary"/>`;
     }
 
     return OEBPS_CONTENT_OPF({
@@ -110,16 +110,20 @@ class EPubFileBuilder {
   }
 
   buildTocXHTML(chapters) {
-    let navContents = "";
+    let navContents = '';
     _.forEach(chapters, (ch, index) => {
       navContents += `
       <dt class="table-of-content">  
         <a href="${ch.id}.xhtml">${index + 1} - ${ch.title} </a>
       </dt>
-      `}
-    )
+      `;
+    });
 
-    const toc_xhtml = OEBPS_TOC_XHTML({ title: this.data.title, language: this.language, navContents });
+    const toc_xhtml = OEBPS_TOC_XHTML({
+      title: this.data.title,
+      language: this.language,
+      navContents,
+    });
     this.zip.addFile('OEBPS/toc.xhtml', toc_xhtml);
   }
 
@@ -131,16 +135,20 @@ class EPubFileBuilder {
           <dt class="table-of-content">  
           <a href="${this.data.chapters[chIdx].id}.xhtml"><img src="${img.src}"/></a>
           </dt>
-        `
-      }).join("\n")
-    }).join("\n");
+        `;
+      }).join('\n');
+    }).join('\n');
 
-    const toc_xhtml = OEBPS_TOC_XHTML({ title: this.data.title, language: this.language, navContents });
+    const toc_xhtml = OEBPS_TOC_XHTML({
+      title: this.data.title,
+      language: this.language,
+      navContents,
+    });
 
     this.zip.addFile('OEBPS/toc.xhtml', toc_xhtml);
   }
   buildTocNCX(chapters) {
-    let navPoints = "";
+    let navPoints = '';
     _.forEach(chapters, (ch, index) => {
       navPoints += `
 		<navPoint id="${ch.id}" playOrder="${index}" class="chapter">
@@ -163,17 +171,29 @@ class EPubFileBuilder {
     this.buildTocNCX(chapters);
   }
   convertGlossary(glossary) {
-    return OEBPS_CONTENT_XHTML({ title: "Glossary", content: glossaryToHTMLString(glossary), language: this.language });
+    return OEBPS_CONTENT_XHTML({
+      title: 'Glossary',
+      content: glossaryToHTMLString(glossary),
+      language: this.language,
+    });
   }
 
   convertChapter(idx, chapter, chapterGlossary) {
-    let text = HTMLFileBuilder.convertChapter(idx, chapter, chapterGlossary, this.data.includeRawLatex, this.videoLinks);
-    
+    let text = HTMLFileBuilder.convertChapter(
+      idx,
+      chapter,
+      chapterGlossary,
+      this.data.includeRawLatex,
+      this.videoLinks,
+      (this.data.sourceType === PlaylistTypes.BoxID) ? this.data.jsonMetadata.shared_link.url : this.data.sourceId,
+      this.data.sourceType,
+    );
+
     // --- Normalize HTML via DOM, strip risky attributes, then XHTML-tidy ---
     try {
       // normalize curly quotes that can break attrs
       text = text
-        .replace(/[\u201C\u201D]/g, '"')  // curly double quotes -> "
+        .replace(/[\u201C\u201D]/g, '"') // curly double quotes -> "
         .replace(/[\u2018\u2019]/g, "'"); // curly single quotes -> '
 
       // Use DOM to normalize attributes & spacing
@@ -181,8 +201,8 @@ class EPubFileBuilder {
       wrapper.innerHTML = text;
 
       // Strip ALL data-* attributes (optional in EPUB, often malformed)
-      wrapper.querySelectorAll('*').forEach(el => {
-        [...el.attributes].forEach(attr => {
+      wrapper.querySelectorAll('*').forEach((el) => {
+        [...el.attributes].forEach((attr) => {
           if (/^data-/.test(attr.name)) {
             el.removeAttribute(attr.name);
           }
@@ -198,7 +218,21 @@ class EPubFileBuilder {
     // Final XHTML safety passes:
     // - self-close <img> tags
     text = text.replace(/<img([^>]*?)>/g, '<img$1 />');
-    const VOID = ['br','hr','meta','link','input','source','track','area','base','col','embed','param','wbr'];
+    const VOID = [
+      'br',
+      'hr',
+      'meta',
+      'link',
+      'input',
+      'source',
+      'track',
+      'area',
+      'base',
+      'col',
+      'embed',
+      'param',
+      'wbr',
+    ];
     const voidRe = new RegExp(`<(${VOID.join('|')})([^/>]*?)>`, 'gi');
     text = text.replace(voidRe, '<$1$2 />');
     const closeVoidRe = new RegExp(`</(?:${VOID.join('|')})\\s*>`, 'gi');
@@ -211,7 +245,7 @@ class EPubFileBuilder {
       </div>
       `);
 
-    return OEBPS_CONTENT_XHTML({ title: chapter.title, content, language: this.language })
+    return OEBPS_CONTENT_XHTML({ title: chapter.title, content, language: this.language });
   }
 
   prepareAndEmbedImages() {
@@ -220,8 +254,8 @@ class EPubFileBuilder {
 
     const rewriteImageObject = (imgObj) => {
       if (!imgObj) return;
-      let buffer = null
-      let mime = null
+      let buffer = null;
+      let mime = null;
       let ext = 'jpg';
 
       if (typeof imgObj.src === 'string' && imgObj.src.startsWith('data:')) {
@@ -256,12 +290,12 @@ class EPubFileBuilder {
           rewriteImageObject.call(this, c);
         }
         if (Array.isArray(c.latex)) {
-          c.latex.forEach(limg => rewriteImageObject.call(this, limg));
+          c.latex.forEach((limg) => rewriteImageObject.call(this, limg));
         }
       }
     };
 
-    (this.data.chapters || []).forEach(ch => {
+    (this.data.chapters || []).forEach((ch) => {
       (ch.contents || []).forEach(scanChapterContent);
     });
 
@@ -270,7 +304,11 @@ class EPubFileBuilder {
 
   convertEPub() {
     _.forEach(this.data.chapters, (ch, idx) => {
-      const contentXHTML = this.convertChapter(idx, ch, this.data.chapterGlossary ? this.data.chapterGlossary[idx] : false);
+      const contentXHTML = this.convertChapter(
+        idx,
+        ch,
+        this.data.chapterGlossary ? this.data.chapterGlossary[idx] : false,
+      );
       this.zip.addFile(`OEBPS/${ch.id}.xhtml`, Buffer.from(contentXHTML));
     });
     if (this.glossary && !_.isEmpty(this.glossary) && !this.data.chapterGlossary) {

--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -1,12 +1,12 @@
 import _ from 'lodash';
 import AdmZip from 'adm-zip';
+import PlaylistTypes from 'entities/Playlists/PlaylistTypes';
 import { _buildID, html } from 'utils';
 import { KATEX_MIN_CSS, PRISM_CSS } from './file-templates/styles';
-import {
-  glossaryToHTMLString,
-} from './GlossaryCreator';
-import { INDEX_HTML_LOCAL, STYLE_CSS/* , PRISM_JS */ } from './file-templates/html';
-import { epubIsText } from './utils';
+import { glossaryToHTMLString } from './GlossaryCreator';
+import { INDEX_HTML_LOCAL, STYLE_CSS /* , PRISM_JS */ } from './file-templates/html';
+import { epubIsText, getSourceLink } from './utils';
+
 
 class HTMLFileBuilder {
   /**
@@ -21,7 +21,7 @@ class HTMLFileBuilder {
   init(parsedData, createLinks = true) {
     this.createLinks = createLinks;
     this.data = parsedData;
-    this.glossary = parsedData.glossary
+    this.glossary = parsedData.glossary;
     this.videoLinks = parsedData.videoLinks;
   }
 
@@ -40,7 +40,7 @@ class HTMLFileBuilder {
   static toHTMLString(parsedData) {
     const builder = new HTMLFileBuilder();
     builder.init(parsedData, false);
-    const html_buffer = builder.getIndexHTML()
+    const html_buffer = builder.getIndexHTML();
     return html_buffer;
   }
 
@@ -48,52 +48,75 @@ class HTMLFileBuilder {
     if (includeRawLatex) {
       content = content.replace(/\$\$(.*?)\$\$/g, `$$$$$1$$$$ \`($1)\``);
     }
-    let text = [
-      '<p>',
-      html.markdown(content),
-      '</p>'
-    ].join("")
-    return text
-  };
-  static convertImage(content, videoLinks) {
+    let text = ['<p>', html.markdown(content), '</p>'].join('');
+    return text;
+  }
+
+  static convertImage(content, videoLinks, sourceId, sourceType) {
     let despId = _buildID();
+    let video_source_url = content.link;
+    if(sourceType !== PlaylistTypes.UploadID) {
+      video_source_url = getSourceLink(sourceId, sourceType, content.timestamp);
+    }
     return [
       '<div class="img-block">',
-      videoLinks && content.link && content.link !== "" ? `<a href="${content.link}">` : "",
+      videoLinks && video_source_url && video_source_url !== '' ? `<a href="${video_source_url}">` : '',
       `\t<img src="${content.src}" alt="${content.alt}" aria-describedby="${despId}" />`,
-      videoLinks && content.link && content.link !== "" ? `</a>` : "",
-      content.descriptions.length !== 0 ? `\t<div id="${despId}">${html.markdown(content.descriptions.join("\n"))}</div>` : "",
-      '</div>'
+      videoLinks && video_source_url && video_source_url !== '' ? `</a>` : '',
+      content.descriptions.length !== 0
+        ? `\t<div id="${despId}">${html.markdown(content.descriptions.join('\n'))}</div>`
+        : '',
+      '</div>',
     ].join('\n');
   }
 
-  static convertContent(content, includeRawLatex, videoLinks) {
+  static convertContent(content, includeRawLatex, videoLinks, sourceId = null, sourceType = null) {
     if (epubIsText(content)) {
       return HTMLFileBuilder.convertText(content, includeRawLatex);
     }
-    return HTMLFileBuilder.convertImage(content, videoLinks);
+    return HTMLFileBuilder.convertImage(content, videoLinks, sourceId, sourceType);
   }
 
-  static convertChapter(idx, chapter, chapterGlossary, includeRawLatex = false, videoLinks = false) {
-    let glossaryText = chapterGlossary ? glossaryToHTMLString(chapterGlossary) : "";
+  static convertChapter(
+    idx,
+    chapter,
+    chapterGlossary,
+    includeRawLatex = false,
+    videoLinks = false,
+    sourceId = null,
+    sourceType = null,
+  ) {
+    let glossaryText = chapterGlossary ? glossaryToHTMLString(chapterGlossary) : '';
     chapter.id = _buildID();
     return [
       // the first chapter has idx 0, but is chapter 1. Thus, we use idx+1
       `<!-- Chapter -->\n<h2 data-ch id="${chapter.id}">${idx + 1}: ${chapter.title}</h2>`,
       `<div class="wrap-text">`,
-      _.map(chapter.contents, (c) => HTMLFileBuilder.convertContent(c, includeRawLatex, videoLinks)).join("\n"),
+      _.map(chapter.contents, (c) =>
+        HTMLFileBuilder.convertContent(c, includeRawLatex, videoLinks, sourceId, sourceType),
+      ).join('\n'),
       `</div>`,
-      glossaryText
-    ].join("\n\n");
+      glossaryText,
+    ].join('\n\n');
   }
 
   convertChapters() {
-    const chapters = this.data.chapters
+    const chapters = this.data.chapters;
     return [
       '<div class="ee-preview-text-con">',
-      _.map(chapters, (ch, idx) => HTMLFileBuilder.convertChapter(idx, ch, this.data.chapterGlossary ? this.data.chapterGlossary[idx] : false, this.data.includeRawLatex, this.videoLinks)).join("\n"),
+      _.map(chapters, (ch, idx) => {
+        return HTMLFileBuilder.convertChapter(
+          idx,
+          ch,
+          this.data.chapterGlossary ? this.data.chapterGlossary[idx] : false,
+          this.data.includeRawLatex,
+          this.videoLinks,
+          (this.data.sourceType === PlaylistTypes.BoxID) ? this.data.jsonMetadata.shared_link.url : this.data.sourceId,
+          this.data.sourceType
+        );
+      }).join('\n'),
       '</div>',
-    ].join("\n");
+    ].join('\n');
   }
   convertVisualTOC() {
     return _.map(this.data.visualTOC, (ch, chIdx) => {
@@ -106,10 +129,10 @@ class HTMLFileBuilder {
           `\t<img src="${img.src}" alt="${img.alt}" aria-describedby="${caption_id}"/>`,
           `\t<p class="wrap-text" id="${caption_id}">${img.alt}</p>`,
           `</a>`,
-          '</div>'
-        ].join("\n");
-      }).join("\n");
-    }).join("\n");
+          '</div>',
+        ].join('\n');
+      }).join('\n');
+    }).join('\n');
   }
   convertTOC() {
     const chapters = this.data.chapters;
@@ -117,15 +140,17 @@ class HTMLFileBuilder {
     return _.map(
       chapters,
       (ch, chIndex) => `
-          <h3><a ${createLinks ? `href="#${ch.id}"` : ""}>${chIndex + 1} - ${ch.title}</a></h3>
+          <h3><a ${createLinks ? `href="#${ch.id}"` : ''}>${chIndex + 1} - ${ch.title}</a></h3>
           <ol>
               ${_.map(
-        ch.subChapters,
-        (subch, subIndex) => `
+                ch.subChapters,
+                (subch, subIndex) => `
             <li>
-              <a ${createLinks ? `href="#${subch.id}"` : ""} >${chIndex + 1}.${subIndex + 1} - ${subch.title}</a>
+              <a ${createLinks ? `href="#${subch.id}"` : ''} >${chIndex + 1}.${subIndex + 1} - ${
+                  subch.title
+                }</a>
             </li>`,
-      ).join('\n')}
+              ).join('\n')}
           </ol>
       `,
     ).join('\n');
@@ -137,21 +162,23 @@ class HTMLFileBuilder {
 
   getIndexHTML() {
     const conversion = this.convertChapters();
-    let toc = "";
+    let toc = '';
     if (this.data.visualTOC) {
       toc = this.convertVisualTOC();
     } else {
       toc = this.convertTOC();
     }
-    return INDEX_HTML_LOCAL({
-      title: this.data.title,
-      navContents: toc,
-      content: conversion,
-      author: this.data.author,
-      cover: this.data.cover,
-      createLinks: this.createLinks,
-      visualTOC: this.data.visualTOC
-    }) + (this.data.chapterGlossary ? "" : HTMLFileBuilder.convertGlossary(this.data.glossary));
+    return (
+      INDEX_HTML_LOCAL({
+        title: this.data.title,
+        navContents: toc,
+        content: conversion,
+        author: this.data.author,
+        cover: this.data.cover,
+        createLinks: this.createLinks,
+        visualTOC: this.data.visualTOC,
+      }) + (this.data.chapterGlossary ? '' : HTMLFileBuilder.convertGlossary(this.data.glossary))
+    );
   }
 
   async getHTMLBuffer() {

--- a/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/HTMLFileBuilder.js
@@ -52,17 +52,13 @@ class HTMLFileBuilder {
     return text;
   }
 
-  static convertImage(content, videoLinks, sourceId, sourceType) {
+  static convertImage(content, videoLinks) {
     let despId = _buildID();
-    let video_source_url = content.link;
-    if(sourceType !== PlaylistTypes.UploadID) {
-      video_source_url = getSourceLink(sourceId, sourceType, content.timestamp);
-    }
     return [
       '<div class="img-block">',
-      videoLinks && video_source_url && video_source_url !== '' ? `<a href="${video_source_url}">` : '',
+      videoLinks && content.link && content.link !== '' ? `<a href="${content.link}">` : '',
       `\t<img src="${content.src}" alt="${content.alt}" aria-describedby="${despId}" />`,
-      videoLinks && video_source_url && video_source_url !== '' ? `</a>` : '',
+      videoLinks && content.link && content.link !== '' ? `</a>` : '',
       content.descriptions.length !== 0
         ? `\t<div id="${despId}">${html.markdown(content.descriptions.join('\n'))}</div>`
         : '',
@@ -70,11 +66,11 @@ class HTMLFileBuilder {
     ].join('\n');
   }
 
-  static convertContent(content, includeRawLatex, videoLinks, sourceId = null, sourceType = null) {
+  static convertContent(content, includeRawLatex, videoLinks) {
     if (epubIsText(content)) {
       return HTMLFileBuilder.convertText(content, includeRawLatex);
     }
-    return HTMLFileBuilder.convertImage(content, videoLinks, sourceId, sourceType);
+    return HTMLFileBuilder.convertImage(content, videoLinks);
   }
 
   static convertChapter(
@@ -92,9 +88,15 @@ class HTMLFileBuilder {
       // the first chapter has idx 0, but is chapter 1. Thus, we use idx+1
       `<!-- Chapter -->\n<h2 data-ch id="${chapter.id}">${idx + 1}: ${chapter.title}</h2>`,
       `<div class="wrap-text">`,
-      _.map(chapter.contents, (c) =>
-        HTMLFileBuilder.convertContent(c, includeRawLatex, videoLinks, sourceId, sourceType),
-      ).join('\n'),
+      _.map(chapter.contents, (c) => {
+        if (!(typeof c === 'string' || "latex" in c)) {
+          c.link = c.link || "";
+          if(sourceType !== PlaylistTypes.UploadID) {
+            c.link = getSourceLink(sourceId, sourceType, c.timestamp ? c.timestamp : "00:00:00");
+          }
+        }
+        return HTMLFileBuilder.convertContent(c, includeRawLatex, videoLinks);
+      }).join('\n'),
       `</div>`,
       glossaryText,
     ].join('\n\n');
@@ -111,7 +113,7 @@ class HTMLFileBuilder {
           this.data.chapterGlossary ? this.data.chapterGlossary[idx] : false,
           this.data.includeRawLatex,
           this.videoLinks,
-          (this.data.sourceType === PlaylistTypes.BoxID) ? this.data.jsonMetadata.shared_link.url : this.data.sourceId,
+          (this.data.sourceType === PlaylistTypes.BoxID) ? this.data.jsonMetadata.shared_link.url : this.data.jsonMetadata.id,
           this.data.sourceType
         );
       }).join('\n'),

--- a/src/screens/EPub/controllers/file-builders/PDFFileBuilder.js
+++ b/src/screens/EPub/controllers/file-builders/PDFFileBuilder.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
+import PlaylistTypes from 'entities/Playlists/PlaylistTypes';
 import { newPDF, STYLE_SHEET, placeholderImg, TextBox } from './file-templates/pdf';
-
+import { getSourceLink } from './utils';
 
 /**
  * File buffer builder for .epub
@@ -137,7 +138,17 @@ class PDFFileBuilder {
   }
 
   convertChapters() {
-    _.forEach(this.data.chapters, (chapter, idx) => this.convertChapter(idx, chapter))
+    _.forEach(this.data.chapters, (chapter, idx) => {
+      _.forEach(chapter.contents, content => {
+        if (!(typeof content === 'string' || "latex" in content)) {
+          content.link = content.link || "";
+          if(this.data.sourceType !== PlaylistTypes.UploadID) {
+            content.link = getSourceLink(this.data.sourceType === PlaylistTypes.BoxID ? this.data.jsonMetadata.shared_link.url : this.data.jsonMetadata.id, this.data.sourceType, content.timestamp ? content.timestamp : "00:00:00");
+          }
+        }
+      });
+      this.convertChapter(idx, chapter)
+    });
   }
   writeGlossaryEntry(key, value) {
     this.writeTextToPDF(`${key}: ${value.description}`, STYLE_SHEET.font.glossary);

--- a/src/screens/EPub/controllers/file-builders/utils.js
+++ b/src/screens/EPub/controllers/file-builders/utils.js
@@ -1,7 +1,25 @@
+import PlaylistTypes from 'entities/Playlists/PlaylistTypes';
+
 export function epubIsText(content) {
-  return typeof content === "string" || (typeof content === "object" && "text" in content);
+  return typeof content === 'string' || (typeof content === 'object' && 'text' in content);
 }
 
 export function epubIsImage(content) {
-  return typeof content === "object" && "src" in content;
+  return typeof content === 'object' && 'src' in content;
+}
+
+export function getSourceLink(sourceId, sourceType, timestamp) {
+  const [hour, minutes, seconds] = timestamp.split(':').map(parseFloat);
+  let time_in_seconds = hour * 3600 + minutes * 60 + seconds;
+  time_in_seconds = Math.floor(time_in_seconds);
+  if (sourceType === PlaylistTypes.YouTubeID) {
+    return `https://www.youtube.com/watch?v=${sourceId}&t=${time_in_seconds}s`;
+  }
+  if (sourceType === PlaylistTypes.KalturaID) {
+    return `https://mediaspace.illinois.edu/media/${sourceId}?st=${time_in_seconds}`;
+  }
+  if (sourceType === PlaylistTypes.BoxID) {
+    return sourceId;
+  }
+  return null;
 }

--- a/src/screens/EPub/service.js
+++ b/src/screens/EPub/service.js
@@ -2,18 +2,20 @@ import { api } from 'utils';
 import ErrorTypes from 'entities/ErrorTypes';
 
 export async function getEPubById(ePubId) {
-    try {
-        const { data } = await api.getEPubById(ePubId);
-        return data;
-    } catch (error) {
-        return ErrorTypes.getError(error);
-    }
+  try {
+    const { data } = await api.getEPubById(ePubId);
+    const source = await api.getMediaById(data.sourceId);
+    data.jsonMetadata = source.data.jsonMetadata;
+    return data;
+  } catch (error) {
+    return ErrorTypes.getError(error);
+  }
 }
 export async function getMediaById(mediaId) {
-    try {
-        const { data } = await api.getMediaById(mediaId);
-        return api.parseMedia(data);
-    } catch (error) {
-        return ErrorTypes.getError(error);
-    }
+  try {
+    const { data } = await api.getMediaById(mediaId);
+    return api.parseMedia(data);
+  } catch (error) {
+    return ErrorTypes.getError(error);
+  }
 }


### PR DESCRIPTION
This PR would update the links being used for images to point to the source rather than the CT website. The changes involve finding the source ID and reconstructing the source link.

### JSON Metadata Propagation
- In `service.js`, when an EPub is fetched, I call `getMediaById` and retrieve the `jsonMetadata` attribute that contains the `id`/ `shared_link.url` (for Box) of the Media on its source website.
- Used to set up getters and setters in `EPubData.js` for the new jsonMetadata field.
- Using `this.data`, I retrieve the sourceId and sourceType.
 
### Link Reconstruction
- When `chapter.content` is an image, I match the sourceType and call the appropriate function to reconstruct the link.
- `getSourceLink` computes the number of seconds to offset the start time and updates the link accordingly
- The PDF file builder had to be handled separately, but used the same pattern.

### Formatting
- Ran prettier to update the file formatting