### PR TITLE
added null checking for image descriptions

### DIFF
--- a/src/screens/EPub/components/ChapterImage/ImageDescription.js
+++ b/src/screens/EPub/components/ChapterImage/ImageDescription.js
@@ -7,8 +7,8 @@ function ImageDescription({
   descriptions,
   onChange
 }) {
-  let myDescriptions = [...descriptions]
   if (Array.isArray(descriptions)) {
+    let myDescriptions = [...descriptions];
     if (descriptions[descriptions.length - 1] !== "") {
       myDescriptions.push("");
     }


### PR DESCRIPTION
I moved the expansion after the `isArray` condition to ensure it's not null, and then continued processing the image descriptions.